### PR TITLE
fix: resolve pcb 0.3.68 deprecation warnings across registry

### DIFF
--- a/Amplifier_Current/INA138.zen
+++ b/Amplifier_Current/INA138.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina138.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -61,7 +60,7 @@ gain_map = {
 load_resistor_value = gain_map[gain_setting]
 
 # External IO
-V_PLUS = io("V+", Power, checks=voltage_within("2.7V to 36V"))  # Power supply (2.7-36V)
+V_PLUS = io("V+", Power(voltage="2.7V to 36V"))  # Power supply (2.7-36V)
 GND = io("GND", Ground)
 
 # Current sensing inputs

--- a/Amplifier_Current/INA138.zen
+++ b/Amplifier_Current/INA138.zen
@@ -74,7 +74,6 @@ OUT = io("OUT", Net)  # Current output (converted to voltage by RL)
 # Internal nets
 _IN_P_FILT = Net("IN_PLUS_FILT") if add_input_filtering else IN_P
 _IN_N_FILT = Net("IN_MINUS_FILT") if add_input_filtering else IN_N
-_OUT_INT = Net("OUT_INT")  # Internal output net before load resistor
 
 # Main component
 Component(
@@ -82,7 +81,7 @@ Component(
     symbol=Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA138"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
     pins={
-        "1": _OUT_INT,  # Output current
+        "1": OUT,  # Output current
         "GND": GND,  # Ground
         "+": _IN_P_FILT,  # V+ input
         "-": _IN_N_FILT,  # V- input
@@ -112,10 +111,7 @@ if add_input_filtering:
 
 # Load resistor to convert output current to voltage
 # Gain = RL * gm where gm = 200µA/V
-Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=_OUT_INT, P2=GND)
-
-# Connect internal output to external output
-OUT = _OUT_INT
+Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=OUT, P2=GND)
 
 # Output filtering (optional)
 if add_output_filtering:

--- a/Amplifier_Current/INA139.zen
+++ b/Amplifier_Current/INA139.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina139.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -61,7 +60,7 @@ gain_map = {
 load_resistor_value = gain_map[gain_setting]
 
 # External IO
-V_PLUS = io("V+", Power, checks=voltage_within("2.7V to 40V"))  # Power supply (2.7-40V)
+V_PLUS = io("V+", Power(voltage="2.7V to 40V"))  # Power supply (2.7-40V)
 GND = io("GND", Ground)
 
 # Current sensing inputs

--- a/Amplifier_Current/INA139.zen
+++ b/Amplifier_Current/INA139.zen
@@ -74,7 +74,6 @@ OUT = io("OUT", Net)  # Current output (converted to voltage by RL)
 # Internal nets
 _IN_P_FILT = Net("IN_PLUS_FILT") if add_input_filtering else IN_P
 _IN_N_FILT = Net("IN_MINUS_FILT") if add_input_filtering else IN_N
-_OUT_INT = Net("OUT_INT")  # Internal output net before load resistor
 
 # Main component
 Component(
@@ -82,7 +81,7 @@ Component(
     symbol=Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA139"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
     pins={
-        "1": _OUT_INT,  # Output current
+        "1": OUT,  # Output current
         "GND": GND,  # Ground
         "+": _IN_P_FILT,  # VIN+ input
         "-": _IN_N_FILT,  # VIN- input
@@ -112,10 +111,7 @@ if add_input_filtering:
 
 # Load resistor to convert output current to voltage
 # Gain = RL * gm where gm = 1000µA/V
-Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=_OUT_INT, P2=GND)
-
-# Connect internal output to external output
-OUT = _OUT_INT
+Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=OUT, P2=GND)
 
 # Output filtering (optional)
 if add_output_filtering:

--- a/Amplifier_Current/INA168.zen
+++ b/Amplifier_Current/INA168.zen
@@ -77,7 +77,6 @@ OUT = io("OUT", Net)  # Current output (converted to voltage by RL)
 # Internal nets
 _IN_P_FILT = Net("IN_PLUS_FILT") if add_input_filtering else IN_P
 _IN_N_FILT = Net("IN_MINUS_FILT") if add_input_filtering else IN_N
-_OUT_INT = Net("OUT_INT")  # Internal output net before load resistor
 
 # Main component
 Component(
@@ -85,7 +84,7 @@ Component(
     symbol=Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA168"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
     pins={
-        "1": _OUT_INT,  # Output current
+        "1": OUT,  # Output current
         "GND": GND,  # Ground
         "+": _IN_P_FILT,  # VIN+ input
         "-": _IN_N_FILT,  # VIN- input
@@ -115,10 +114,7 @@ if add_input_filtering:
 
 # Load resistor to convert output current to voltage
 # Gain = RL * gm where gm = 200µA/V
-Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=_OUT_INT, P2=GND)
-
-# Connect internal output to external output
-OUT = _OUT_INT
+Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=OUT, P2=GND)
 
 # Output filtering (optional)
 if add_output_filtering:

--- a/Amplifier_Current/INA168.zen
+++ b/Amplifier_Current/INA168.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina168.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -64,7 +63,7 @@ gain_map = {
 load_resistor_value = gain_map[gain_setting]
 
 # External IO
-V_PLUS = io("V+", Power, checks=voltage_within("2.7V to 60V"))  # Power supply (2.7-60V)
+V_PLUS = io("V+", Power(voltage="2.7V to 60V"))  # Power supply (2.7-60V)
 GND = io("GND", Ground)
 
 # Current sensing inputs

--- a/Amplifier_Current/INA169.zen
+++ b/Amplifier_Current/INA169.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina169.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -63,7 +62,7 @@ gain_map = {
 load_resistor_value = gain_map[gain_setting]
 
 # External IO
-V_PLUS = io("V+", Power, checks=voltage_within("2.7V to 60V"))  # Power supply (2.7-60V)
+V_PLUS = io("V+", Power(voltage="2.7V to 60V"))  # Power supply (2.7-60V)
 GND = io("GND", Ground)
 
 # Current sensing inputs

--- a/Amplifier_Current/INA169.zen
+++ b/Amplifier_Current/INA169.zen
@@ -76,7 +76,6 @@ OUT = io("OUT", Net)  # Current output (converted to voltage by RL)
 # Internal nets
 _IN_P_FILT = Net("IN_PLUS_FILT") if add_input_filtering else IN_P
 _IN_N_FILT = Net("IN_MINUS_FILT") if add_input_filtering else IN_N
-_OUT_INT = Net("OUT_INT")  # Internal output net before load resistor
 
 # Main component
 Component(
@@ -84,7 +83,7 @@ Component(
     symbol=Symbol(library="@kicad-symbols/Amplifier_Current.kicad_sym", name="INA169"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
     pins={
-        "1": _OUT_INT,  # Output current
+        "1": OUT,  # Output current
         "GND": GND,  # Ground
         "+": _IN_P_FILT,  # VIN+ input
         "-": _IN_N_FILT,  # VIN- input
@@ -115,10 +114,7 @@ if add_input_filtering:
 
 # Load resistor to convert output current to voltage
 # Gain = RL * gm where gm = 1000µA/V
-Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=_OUT_INT, P2=GND)
-
-# Connect internal output to external output
-OUT = _OUT_INT
+Resistor(name="R_LOAD", value=load_resistor_value, package="0603", P1=OUT, P2=GND)
 
 # Output filtering (optional)
 if add_output_filtering:

--- a/Analog/PGA112.zen
+++ b/Analog/PGA112.zen
@@ -26,7 +26,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/pga112.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -58,12 +57,12 @@ add_spi_pullup = config("add_spi_pullup", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-AVDD = io("AVDD", Power, checks=voltage_within("2.2V to 5.5V"))
+AVDD = io("AVDD", Power(voltage="2.2V to 5.5V"))
 GND = io("GND", Ground)
 
 # Digital supply - separate or tied to AVDD
 if split_supplies:
-    DVDD = io("DVDD", Power, checks=voltage_within("2.2V to 5.5V"))
+    DVDD = io("DVDD", Power(voltage="2.2V to 5.5V"))
 else:
     DVDD = AVDD
 

--- a/Analog/PGA112.zen
+++ b/Analog/PGA112.zen
@@ -58,12 +58,12 @@ add_spi_pullup = config("add_spi_pullup", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-AVDD = io("AVDD", Power, default=Power("AVDD"), checks=voltage_within("2.2V to 5.5V"))
+AVDD = io("AVDD", Power, checks=voltage_within("2.2V to 5.5V"))
 GND = io("GND", Ground)
 
 # Digital supply - separate or tied to AVDD
 if split_supplies:
-    DVDD = io("DVDD", Power, default=Power("DVDD"), checks=voltage_within("2.2V to 5.5V"))
+    DVDD = io("DVDD", Power, checks=voltage_within("2.2V to 5.5V"))
 else:
     DVDD = AVDD
 
@@ -73,10 +73,6 @@ spi = io("SPI", Spi)
 # VREF input/output based on configuration
 if vref_config == VrefConfiguration("External"):
     VREF = io("VREF", Net)
-elif vref_config == VrefConfiguration("MidSupply"):
-    VREF = io("VREF", Net)  # Will be generated internally
-else:  # Ground
-    VREF = GND
 
 # Analog inputs
 CH0 = io("CH0", Net)
@@ -85,25 +81,30 @@ CH1 = io("CH1", Net)
 # Analog output
 VOUT = io("VOUT", Net)
 
-# Internal nets
-_AVDD = Net("_AVDD")  # Filtered analog supply
-_DVDD = Net("_DVDD")  # Filtered digital supply
-_VREF = Net("_VREF")  # Internal VREF net
-_VOUT_INT = Net("_VOUT_INT")  # Internal output before series resistor
-_DIO = Net("_DIO")  # SPI data I/O
-
-# Power filtering
+# Internal nets — filtered supplies and derived references
 if add_ferrite_beads:
-    # Analog supply filtering
-    FerriteBead(name="FB_AVDD", package="0603", P1=AVDD, P2=_AVDD)
-    # Digital supply filtering (if separate)
-    if split_supplies:
-        FerriteBead(name="FB_DVDD", package="0603", P1=DVDD, P2=_DVDD)
-    else:
-        _DVDD = _AVDD
+    _AVDD = Net("_AVDD")
+    _DVDD = Net("_DVDD") if split_supplies else _AVDD
 else:
     _AVDD = AVDD
     _DVDD = DVDD
+
+# VREF internal node: external io, mid-supply node, or ground
+if vref_config == VrefConfiguration("External"):
+    _VREF = VREF
+elif vref_config == VrefConfiguration("MidSupply"):
+    _VREF = Net("_VREF")
+else:  # Ground
+    _VREF = GND
+
+_VOUT_INT = Net("_VOUT_INT") if add_output_series_resistor else VOUT
+_DIO = spi.MOSI  # PGA112 uses a bidirectional DIO pin; driven by MOSI on writes
+
+# Power filtering
+if add_ferrite_beads:
+    FerriteBead(name="FB_AVDD", package="0603", P1=AVDD, P2=_AVDD)
+    if split_supplies:
+        FerriteBead(name="FB_DVDD", package="0603", P1=DVDD, P2=_DVDD)
 
 # Bulk capacitors
 if add_bulk_cap:
@@ -122,11 +123,6 @@ if vref_config == VrefConfiguration("MidSupply"):
     Resistor(name="R_VREF1", value="10kohms", package="0402", P1=_AVDD, P2=_VREF)
     Resistor(name="R_VREF2", value="10kohms", package="0402", P1=_VREF, P2=GND)
     Capacitor(name="C_VREF", value="1uF", voltage="10V", package="0603", P1=_VREF, P2=GND)
-    VREF = _VREF
-elif vref_config == VrefConfiguration("External"):
-    _VREF = VREF
-else:  # Ground
-    _VREF = GND
 
 # Main component
 Component(
@@ -150,13 +146,6 @@ Component(
 # Output circuit
 if add_output_series_resistor:
     Resistor(name="R_OUT", value=output_series_resistor_value, package="0402", P1=_VOUT_INT, P2=VOUT)
-else:
-    VOUT = _VOUT_INT
-
-# SPI interface configuration
-_DIO = spi.MOSI  # For write operations
-# Note: PGA112 uses DIO pin for both input and output
-# The actual bidirectional behavior is handled by the IC
 
 # SPI pull-up resistor on CS
 Resistor(name="R_CS_PU", value="10kohms", package="0402", P1=spi.CS, P2=_DVDD, dnp=not add_spi_pullup)

--- a/Analog/PGA113.zen
+++ b/Analog/PGA113.zen
@@ -47,12 +47,12 @@ add_spi_pullup = config("add_spi_pullup", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-AVDD = io("AVDD", Power, default=Power("AVDD"), checks=voltage_within("2.2V to 5.5V"))
+AVDD = io("AVDD", Power, checks=voltage_within("2.2V to 5.5V"))
 GND = io("GND", Ground)
 
 # Digital supply - separate or tied to AVDD
 if split_supplies:
-    DVDD = io("DVDD", Power, default=Power("DVDD"), checks=voltage_within("2.2V to 5.5V"))
+    DVDD = io("DVDD", Power, checks=voltage_within("2.2V to 5.5V"))
 else:
     DVDD = AVDD
 
@@ -62,10 +62,6 @@ spi = io("SPI", Spi)
 # VREF input/output based on configuration
 if vref_config == VrefConfiguration("External"):
     VREF = io("VREF", Net)
-elif vref_config == VrefConfiguration("MidSupply"):
-    VREF = io("VREF", Net)  # Will be generated internally
-else:  # Ground
-    VREF = GND
 
 # Analog inputs
 CH0 = io("CH0", Net)
@@ -74,25 +70,30 @@ CH1 = io("CH1", Net)
 # Analog output
 VOUT = io("VOUT", Net)
 
-# Internal nets
-_AVDD = Net("_AVDD")  # Filtered analog supply
-_DVDD = Net("_DVDD")  # Filtered digital supply
-_VREF = Net("_VREF")  # Internal VREF net
-_VOUT_INT = Net("_VOUT_INT")  # Internal output before series resistor
-_DIO = Net("_DIO")  # SPI data I/O
-
-# Power filtering
+# Internal nets — filtered supplies and derived references
 if add_ferrite_beads:
-    # Analog supply filtering
-    FerriteBead(name="FB_AVDD", package="0603", P1=AVDD, P2=_AVDD)
-    # Digital supply filtering (if separate)
-    if split_supplies:
-        FerriteBead(name="FB_DVDD", package="0603", P1=DVDD, P2=_DVDD)
-    else:
-        _DVDD = _AVDD
+    _AVDD = Net("_AVDD")
+    _DVDD = Net("_DVDD") if split_supplies else _AVDD
 else:
     _AVDD = AVDD
     _DVDD = DVDD
+
+# VREF internal node: external io, mid-supply node, or ground
+if vref_config == VrefConfiguration("External"):
+    _VREF = VREF
+elif vref_config == VrefConfiguration("MidSupply"):
+    _VREF = Net("_VREF")
+else:  # Ground
+    _VREF = GND
+
+_VOUT_INT = Net("_VOUT_INT") if add_output_series_resistor else VOUT
+_DIO = spi.MOSI  # PGA113 uses a bidirectional DIO pin; driven by MOSI on writes
+
+# Power filtering
+if add_ferrite_beads:
+    FerriteBead(name="FB_AVDD", package="0603", P1=AVDD, P2=_AVDD)
+    if split_supplies:
+        FerriteBead(name="FB_DVDD", package="0603", P1=DVDD, P2=_DVDD)
 
 # Bulk capacitors
 if add_bulk_cap:
@@ -111,11 +112,6 @@ if vref_config == VrefConfiguration("MidSupply"):
     Resistor(name="R_VREF1", value="10kohms", package="0402", P1=_AVDD, P2=_VREF)
     Resistor(name="R_VREF2", value="10kohms", package="0402", P1=_VREF, P2=GND)
     Capacitor(name="C_VREF", value="1uF", voltage="10V", package="0603", P1=_VREF, P2=GND)
-    VREF = _VREF
-elif vref_config == VrefConfiguration("External"):
-    _VREF = VREF
-else:  # Ground
-    _VREF = GND
 
 # Main component
 Component(
@@ -139,13 +135,6 @@ Component(
 # Output circuit
 if add_output_series_resistor:
     Resistor(name="R_OUT", value=output_series_resistor_value, package="0402", P1=_VOUT_INT, P2=VOUT)
-else:
-    VOUT = _VOUT_INT
-
-# SPI interface configuration
-_DIO = spi.MOSI  # For write operations
-# Note: PGA113 uses DIO pin for both input and output
-# The actual bidirectional behavior is handled by the IC
 
 # SPI pull-up resistor on CS
 Resistor(name="R_CS_PU", value="10kohms", package="0402", P1=spi.CS, P2=_DVDD, dnp=not add_spi_pullup)

--- a/Analog/PGA113.zen
+++ b/Analog/PGA113.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/pga113.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -47,12 +46,12 @@ add_spi_pullup = config("add_spi_pullup", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-AVDD = io("AVDD", Power, checks=voltage_within("2.2V to 5.5V"))
+AVDD = io("AVDD", Power(voltage="2.2V to 5.5V"))
 GND = io("GND", Ground)
 
 # Digital supply - separate or tied to AVDD
 if split_supplies:
-    DVDD = io("DVDD", Power, checks=voltage_within("2.2V to 5.5V"))
+    DVDD = io("DVDD", Power(voltage="2.2V to 5.5V"))
 else:
     DVDD = AVDD
 

--- a/Analog_ADC/AD7171.zen
+++ b/Analog_ADC/AD7171.zen
@@ -35,6 +35,7 @@ VDD = io("VDD", Power)
 AIN_P = io("AIN+", Net)
 AIN_N = io("AIN-", Net)
 PDRST_CTRL = io("PDRST", Net, optional=True)
+_PDRST_CTRL = PDRST_CTRL if PDRST_CTRL != None else Net("nPDRST")
 if use_external_ref:
     REFIN_P = io("REFIN+", Net)
     REFIN_N = io("REFIN-", Ground)
@@ -43,7 +44,7 @@ GND = io("GND", Ground)
 # Internal nets
 _VREF = REFIN_P if use_external_ref else VDD
 _VREF_N = REFIN_N if use_external_ref else GND
-_PDRST = PDRST_CTRL if power_on_delay != PowerOnDelay("0ms") else VDD
+_PDRST = _PDRST_CTRL if power_on_delay != PowerOnDelay("0ms") else VDD
 
 # Filtered analog inputs (if filtering is enabled)
 if add_input_filter:

--- a/Analog_ADC/AD7171.zen
+++ b/Analog_ADC/AD7171.zen
@@ -30,13 +30,13 @@ if add_input_filter:
     input_filter_type = config("filter_type", FilterType, default="265kHz")
 
 # External IO
-spi = io("SPI", Spi, default=Spi("SPI"))
+spi = io("SPI", Spi)
 VDD = io("VDD", Power)
-AIN_P = io("AIN+", Net, default=Net("AIN+"))
-AIN_N = io("AIN-", Net, default=Net("AIN-"))
-PDRST_CTRL = io("PDRST", Net, default=Net("nPDRST"), optional=True)
+AIN_P = io("AIN+", Net)
+AIN_N = io("AIN-", Net)
+PDRST_CTRL = io("PDRST", Net, optional=True)
 if use_external_ref:
-    REFIN_P = io("REFIN+", Net, default=Net("VREF+"))
+    REFIN_P = io("REFIN+", Net)
     REFIN_N = io("REFIN-", Ground)
 GND = io("GND", Ground)
 

--- a/Analog_ADC/ADS1013IDGS.zen
+++ b/Analog_ADC/ADS1013IDGS.zen
@@ -100,12 +100,9 @@ Component(
     footprint=File("@kicad-footprints/Package_SO.pretty/TSSOP-10_3x3mm_P0.5mm.kicad_mod"),
     pins={
         "ADDR": _ADDR_NET,
-        "2": NotConnected(),
         "GND": GND,
         "AIN0": _AIN0_FILTERED,
         "AIN1": _AIN1_FILTERED,
-        "6": NotConnected(),
-        "7": NotConnected(),
         "VDD": VDD,
         "SDA": i2c.SDA,
         "SCL": i2c.SCL,

--- a/Analog_ADC/ADS1013IDGS.zen
+++ b/Analog_ADC/ADS1013IDGS.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads1013.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -64,7 +63,7 @@ if add_analog_filtering:
     filter_c_value = config("filter_c_value", Capacitance, default="100pF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("2V to 5.5V"))
+VDD = io("VDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Analog_ADC/ADS1014IDGS.zen
+++ b/Analog_ADC/ADS1014IDGS.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads1014.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -69,7 +68,7 @@ if add_analog_filtering:
     filter_c_value = config("filter_c_value", Capacitance, default="100pF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("2V to 5.5V"))
+VDD = io("VDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Analog_ADC/ADS1014IDGS.zen
+++ b/Analog_ADC/ADS1014IDGS.zen
@@ -113,8 +113,6 @@ Component(
         "GND": GND,
         "AIN0": _AIN0_FILTERED,
         "AIN1": _AIN1_FILTERED,
-        "6": NotConnected(),
-        "7": NotConnected(),
         "VDD": VDD,
         "SDA": i2c.SDA,
         "SCL": i2c.SCL,

--- a/Analog_ADC/ADS1015IDGS.zen
+++ b/Analog_ADC/ADS1015IDGS.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads1015.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -70,7 +69,7 @@ if add_analog_filtering:
     filter_c_value = config("filter_c_value", Capacitance, default="100pF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("2V to 5.5V"))
+VDD = io("VDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Analog_ADC/ADS1113IDGS.zen
+++ b/Analog_ADC/ADS1113IDGS.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads1113.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -64,7 +63,7 @@ if add_analog_filtering:
     filter_c_value = config("filter_c_value", Capacitance, default="100pF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("2V to 5.5V"))
+VDD = io("VDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Analog_ADC/ADS1113IDGS.zen
+++ b/Analog_ADC/ADS1113IDGS.zen
@@ -100,12 +100,9 @@ Component(
     footprint=File("@kicad-footprints/Package_SO.pretty/TSSOP-10_3x3mm_P0.5mm.kicad_mod"),
     pins={
         "ADDR": _ADDR_NET,
-        "2": NotConnected(),  # NC pin
         "GND": GND,
         "AIN0": _AIN0_FILTERED,
         "AIN1": _AIN1_FILTERED,
-        "6": NotConnected(),  # NC pin
-        "7": NotConnected(),  # NC pin
         "VDD": VDD,
         "SDA": i2c.SDA,
         "SCL": i2c.SCL,

--- a/Analog_ADC/ADS1114IDGS.zen
+++ b/Analog_ADC/ADS1114IDGS.zen
@@ -114,8 +114,6 @@ Component(
         "GND": GND,
         "AIN0": _AIN0_FILTERED,
         "AIN1": _AIN1_FILTERED,
-        "6": NotConnected(),
-        "7": NotConnected(),
         "VDD": VDD,
         "SDA": i2c.SDA,
         "SCL": i2c.SCL,

--- a/Analog_ADC/ADS1114IDGS.zen
+++ b/Analog_ADC/ADS1114IDGS.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads1114.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -70,7 +69,7 @@ if add_analog_filtering:
     filter_c_value = config("filter_c_value", Capacitance, default="100pF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("2V to 5.5V"))
+VDD = io("VDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Analog_ADC/ADS1115IDGS.zen
+++ b/Analog_ADC/ADS1115IDGS.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads1115.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -70,7 +69,7 @@ if add_analog_filtering:
     filter_c_value = config("filter_c_value", Capacitance, default="100pF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("2V to 5.5V"))
+VDD = io("VDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Analog_ADC/ADS7029.zen
+++ b/Analog_ADC/ADS7029.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7029-q1.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,8 +55,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("2.35V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="2.35V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7039.zen
+++ b/Analog_ADC/ADS7039.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7039-q1.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,8 +55,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("2.35V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="2.35V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7040.zen
+++ b/Analog_ADC/ADS7040.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7040.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,8 +55,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("1.65V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="1.65V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7041.zen
+++ b/Analog_ADC/ADS7041.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7041.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,8 +55,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("1.65V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="1.65V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7042.zen
+++ b/Analog_ADC/ADS7042.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7042.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,8 +54,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("1.65V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="1.65V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7043.zen
+++ b/Analog_ADC/ADS7043.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7043.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,8 +55,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("1.65V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="1.65V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7044.zen
+++ b/Analog_ADC/ADS7044.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7044.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,8 +54,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("1.65V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="1.65V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7049.zen
+++ b/Analog_ADC/ADS7049.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7049-q1.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,8 +55,8 @@ if filter_configuration == FilterConfiguration("AntiAliasing"):
 add_spi_pullup = config("add_spi_pullup", bool, default=True)
 
 # External power supplies
-AVDD = io("AVDD", Power, checks=voltage_within("2.35V to 3.6V"))
-DVDD = io("DVDD", Power, checks=voltage_within("1.65V to 3.6V"))
+AVDD = io("AVDD", Power(voltage="2.35V to 3.6V"))
+DVDD = io("DVDD", Power(voltage="1.65V to 3.6V"))
 GND = io("GND", Ground)
 
 # Analog inputs

--- a/Analog_ADC/ADS7866.zen
+++ b/Analog_ADC/ADS7866.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7866.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -48,7 +47,7 @@ if add_decoupling_caps:
     bulk_cap_value = config("bulk_cap_value", Capacitance, default="10uF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("1.2V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.2V to 3.6V"))
 GND = io("GND", Ground)
 
 # SPI interface - using subset of standard SPI

--- a/Analog_ADC/ADS7867.zen
+++ b/Analog_ADC/ADS7867.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7867.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -48,7 +47,7 @@ if add_decoupling_caps:
     bulk_cap_value = config("bulk_cap_value", Capacitance, default="10uF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("1.2V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.2V to 3.6V"))
 GND = io("GND", Ground)
 
 # SPI interface - using subset of standard SPI

--- a/Analog_ADC/ADS7868.zen
+++ b/Analog_ADC/ADS7868.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7868.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -48,7 +47,7 @@ if add_decoupling_caps:
     bulk_cap_value = config("bulk_cap_value", Capacitance, default="10uF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("1.2V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.2V to 3.6V"))
 GND = io("GND", Ground)
 
 # SPI interface - using subset of standard SPI

--- a/Analog_DAC/AD5691R.zen
+++ b/Analog_DAC/AD5691R.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/A
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -75,12 +74,12 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # VLOGIC supply for MSOP package
 if add_vlogic_supply:
-    VLOGIC = io("VLOGIC", Power, checks=voltage_within("2.7V to 5.5V"))
+    VLOGIC = io("VLOGIC", Power(voltage="2.7V to 5.5V"))
     _VLOGIC = VLOGIC
 else:
     _VLOGIC = VDD  # Use VDD for VLOGIC if not separate

--- a/Analog_DAC/AD5692R.zen
+++ b/Analog_DAC/AD5692R.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/a
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -75,12 +74,12 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # VLOGIC supply for MSOP package
 if add_vlogic_supply:
-    VLOGIC = io("VLOGIC", Power, checks=voltage_within("2.7V to 5.5V"))
+    VLOGIC = io("VLOGIC", Power(voltage="2.7V to 5.5V"))
     _VLOGIC = VLOGIC
 else:
     _VLOGIC = VDD  # Use VDD for VLOGIC if not separate

--- a/Analog_DAC/AD5693R.zen
+++ b/Analog_DAC/AD5693R.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/A
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -75,12 +74,12 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # VLOGIC supply for MSOP package
 if add_vlogic_supply:
-    VLOGIC = io("VLOGIC", Power, checks=voltage_within("2.7V to 5.5V"))
+    VLOGIC = io("VLOGIC", Power(voltage="2.7V to 5.5V"))
     _VLOGIC = VLOGIC
 else:
     _VLOGIC = VDD  # Use VDD for VLOGIC if not separate

--- a/Analog_DAC/ADS7830.zen
+++ b/Analog_DAC/ADS7830.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ads7830.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance", "Voltage")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -65,7 +64,7 @@ if add_analog_filtering:
     filter_c_value = config("filter_c_value", Capacitance, default="10pF")
 
 # External power supply
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Analog_DAC/ADS7830.zen
+++ b/Analog_DAC/ADS7830.zen
@@ -72,17 +72,17 @@ GND = io("GND", Ground)
 i2c = io("I2C", I2c)
 
 # Analog inputs
-CH0 = io("CH0", Net, default=Net("CH0"))
-CH1 = io("CH1", Net, default=Net("CH1"))
-CH2 = io("CH2", Net, default=Net("CH2"))
-CH3 = io("CH3", Net, default=Net("CH3"))
-CH4 = io("CH4", Net, default=Net("CH4"))
-CH5 = io("CH5", Net, default=Net("CH5"))
-CH6 = io("CH6", Net, default=Net("CH6"))
-CH7 = io("CH7", Net, default=Net("CH7"))
+CH0 = io("CH0", Net)
+CH1 = io("CH1", Net)
+CH2 = io("CH2", Net)
+CH3 = io("CH3", Net)
+CH4 = io("CH4", Net)
+CH5 = io("CH5", Net)
+CH6 = io("CH6", Net)
+CH7 = io("CH7", Net)
 
 # Common input for single-ended mode
-COM = io("COM", Net, default=Net("COM"))
+COM = io("COM", Net)
 
 # External reference input (if used)
 if reference_mode == ReferenceMode("External"):

--- a/Analog_DAC/ADS7830.zen
+++ b/Analog_DAC/ADS7830.zen
@@ -114,11 +114,11 @@ _A1_NET = VDD if a1_state else GND
 _A0_NET = VDD if a0_state else GND
 
 # Reference pin connection
-_REF_NET = Net("REF")
 if reference_mode == ReferenceMode("External"):
-    _REF_CONNECT = REF_EXT
     _REF_NET = REF_EXT
+    _REF_CONNECT = REF_EXT
 else:
+    _REF_NET = Net("REF")
     _REF_CONNECT = _REF_NET
 
 # Main component

--- a/Analog_DAC/DAC5311.zen
+++ b/Analog_DAC/DAC5311.zen
@@ -32,7 +32,7 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-AVDD = io("AVDD", Power, default=Power("AVDD"), checks=voltage_within("2V to 5.5V"))
+AVDD = io("AVDD", Power, checks=voltage_within("2V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC5311.zen
+++ b/Analog_DAC/DAC5311.zen
@@ -12,7 +12,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/dac5311.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -32,7 +31,7 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-AVDD = io("AVDD", Power, checks=voltage_within("2V to 5.5V"))
+AVDD = io("AVDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC6311.zen
+++ b/Analog_DAC/DAC6311.zen
@@ -32,7 +32,7 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-AVDD = io("AVDD", Power, default=Power("AVDD"), checks=voltage_within("2V to 5.5V"))
+AVDD = io("AVDD", Power, checks=voltage_within("2V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC6311.zen
+++ b/Analog_DAC/DAC6311.zen
@@ -12,7 +12,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/dac6311.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -32,7 +31,7 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-AVDD = io("AVDD", Power, checks=voltage_within("2V to 5.5V"))
+AVDD = io("AVDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC7311.zen
+++ b/Analog_DAC/DAC7311.zen
@@ -12,7 +12,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/dac7311.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -32,7 +31,7 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-AVDD = io("AVDD", Power, checks=voltage_within("2V to 5.5V"))
+AVDD = io("AVDD", Power(voltage="2V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC7311.zen
+++ b/Analog_DAC/DAC7311.zen
@@ -32,7 +32,7 @@ if add_output_filtering:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-AVDD = io("AVDD", Power, default=Power("AVDD"), checks=voltage_within("2V to 5.5V"))
+AVDD = io("AVDD", Power, checks=voltage_within("2V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC7513.zen
+++ b/Analog_DAC/DAC7513.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/dac7513.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -43,7 +42,7 @@ else:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC7513.zen
+++ b/Analog_DAC/DAC7513.zen
@@ -43,7 +43,7 @@ else:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, default=Power("VDD"), checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC8531E.zen
+++ b/Analog_DAC/DAC8531E.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/dac8531.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -44,7 +43,7 @@ add_output_feedback_path = config("add_output_feedback_path", bool, default=True
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS

--- a/Analog_DAC/DAC8531E.zen
+++ b/Analog_DAC/DAC8531E.zen
@@ -44,7 +44,7 @@ add_output_feedback_path = config("add_output_feedback_path", bool, default=True
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, default=Power("VDD"), checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # SPI interface - Note: This is SPI-compatible but uses SYNC instead of CS
@@ -61,9 +61,10 @@ VOUT = io("VOUT", Net)
 
 # Output feedback
 if add_output_feedback_path:
-    VFB = io("VFB", Net, default=VOUT)  # Default to direct connection
+    VFB = io("VFB", Net, optional=True)
+    _vfb_pin = VFB if VFB != None else VOUT
 else:
-    VFB = Net("VFB")  # Internal net
+    _vfb_pin = Net("VFB")  # Internal net
 
 # Internal nets
 _VOUT_INT = Net("VOUT_INT") if add_output_filtering else VOUT
@@ -81,7 +82,7 @@ Component(
         "V_{REF}": _VREF_FILT,
         "GND": GND,
         "V_{DD}": VDD,
-        "V_{FB}": VFB,
+        "V_{FB}": _vfb_pin,
         "V_{OUT}": _VOUT_INT,
     },
 )

--- a/Analog_DAC/MCP4725.zen
+++ b/Analog_DAC/MCP4725.zen
@@ -21,7 +21,6 @@ Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/22039d.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -60,7 +59,7 @@ i2c_address = config("i2c_address", I2cAddress, default=I2cAddress("0x60"))
 
 # External IO
 i2c = io("I2C", I2c)
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5.5V"))
 VSS = io("VSS", Ground)
 VOUT = io("VOUT", Net)
 

--- a/Analog_DAC/MCP4725.zen
+++ b/Analog_DAC/MCP4725.zen
@@ -59,21 +59,24 @@ add_output_filter = config("add_output_filter", bool, default=True)
 i2c_address = config("i2c_address", I2cAddress, default=I2cAddress("0x60"))
 
 # External IO
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
 VSS = io("VSS", Ground)
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VOUT = io("VOUT", Net)
 
 # A0 pin configuration based on selected I2C address
 _factory_version, _a0_connection = address_map[i2c_address]
 _A0 = VDD if _a0_connection == "VDD" else VSS
+
+# Internal chip output node — pre-filter when output filter is enabled
+_VOUT_CHIP = Net("VOUT_CHIP") if add_output_filter else VOUT
 
 # 12-bit Digital-to-Analog Converter, integrated EEPROM, I2C interface, SOT-23-6
 Component(
     name="MCP4725",
     symbol=Symbol(library="@kicad-symbols/Analog_DAC.kicad_sym", name="MCP4725xxx-xCH"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-6.kicad_mod"),
-    pins={"SCL": i2c.SCL, "SDA": i2c.SDA, "A0": _A0, "VDD": VDD, "VSS": VSS, "VOUT": VOUT},
+    pins={"SCL": i2c.SCL, "SDA": i2c.SDA, "A0": _A0, "VDD": VDD, "VSS": VSS, "VOUT": _VOUT_CHIP},
 )
 
 # Power Supply Decoupling - Datasheet recommends 0.1µF ceramic capacitor
@@ -97,14 +100,10 @@ if add_i2c_pullups:
 # Optional Output Filter - For noise-sensitive applications
 if add_output_filter:
     # Series resistor for RC filter (100-1k ohm typical)
-    _VOUT_FILTERED = Net("VOUT_FILTERED")
-    Resistor(name="R_FILTER", value="100ohms", package="0402", P1=VOUT, P2=_VOUT_FILTERED)
+    Resistor(name="R_FILTER", value="100ohms", package="0402", P1=_VOUT_CHIP, P2=VOUT)
 
     # Filter capacitor (100pF-1nF typical, depends on bandwidth requirements)
-    Capacitor(name="C_FILTER", value="100pF", package="0402", P1=_VOUT_FILTERED, P2=VSS)
-
-    # Update output net to filtered version
-    VOUT = _VOUT_FILTERED
+    Capacitor(name="C_FILTER", value="100pF", package="0402", P1=VOUT, P2=VSS)
 
 # pcb:sch MCP4725 x=405.4000 y=214.9000 rot=0
 # pcb:sch C_DEC.C x=92.9800 y=227.6000 rot=0

--- a/Analog_DAC/MCP4728.zen
+++ b/Analog_DAC/MCP4728.zen
@@ -37,15 +37,21 @@ add_output_filters = config("add_output_filters", bool, default=True)
 i2c_address = config("i2c_address", I2cAddress, default=I2cAddress("0x60"))
 
 # External IO
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 VDD = io("VDD", Power)
 VSS = io("VSS", Ground)
-LDAC = io("LDAC", Net, default=Net("LDAC"))
-RDY_BSY = io("RDY_BSY", Net, default=Net("RDY_BSY"))
-VOUTA = io("VOUTA", Net, default=Net("VOUTA"))
-VOUTB = io("VOUTB", Net, default=Net("VOUTB"))
-VOUTC = io("VOUTC", Net, default=Net("VOUTC"))
-VOUTD = io("VOUTD", Net, default=Net("VOUTD"))
+LDAC = io("LDAC", Net)
+RDY_BSY = io("RDY_BSY", Net)
+VOUTA = io("VOUTA", Net)
+VOUTB = io("VOUTB", Net)
+VOUTC = io("VOUTC", Net)
+VOUTD = io("VOUTD", Net)
+
+# Internal chip output nodes — pre-filter when output filters are enabled
+_VOUTA_CHIP = Net("VOUTA_CHIP") if add_output_filters else VOUTA
+_VOUTB_CHIP = Net("VOUTB_CHIP") if add_output_filters else VOUTB
+_VOUTC_CHIP = Net("VOUTC_CHIP") if add_output_filters else VOUTC
+_VOUTD_CHIP = Net("VOUTD_CHIP") if add_output_filters else VOUTD
 
 # 12-bit quad digital to analog converter, 2.048V internal reference, integrated EEPROM, I2C interface
 Component(
@@ -58,10 +64,10 @@ Component(
         "SDA": i2c.SDA,
         "~{LDAC}": LDAC,
         "RDY/~{BSY}": RDY_BSY,
-        "VOUTA": VOUTA,
-        "VOUTB": VOUTB,
-        "VOUTC": VOUTC,
-        "VOUTD": VOUTD,
+        "VOUTA": _VOUTA_CHIP,
+        "VOUTB": _VOUTB_CHIP,
+        "VOUTC": _VOUTC_CHIP,
+        "VOUTD": _VOUTD_CHIP,
         "VSS": VSS,
     },
 )
@@ -105,28 +111,20 @@ elif ldac_config == LDACConfig("PullDown"):
 # Optional Output Filters - For noise-sensitive applications
 if add_output_filters:
     # Channel A output filter
-    _VOUTA_FILTERED = Net("VOUTA_FILTERED")
-    Resistor(name="R_FILTER_A", value="100ohms", package="0402", P1=VOUTA, P2=_VOUTA_FILTERED)
-    Capacitor(name="C_FILTER_A", value="100pF", package="0402", P1=_VOUTA_FILTERED, P2=VSS)
-    VOUTA = _VOUTA_FILTERED
+    Resistor(name="R_FILTER_A", value="100ohms", package="0402", P1=_VOUTA_CHIP, P2=VOUTA)
+    Capacitor(name="C_FILTER_A", value="100pF", package="0402", P1=VOUTA, P2=VSS)
 
     # Channel B output filter
-    _VOUTB_FILTERED = Net("VOUTB_FILTERED")
-    Resistor(name="R_FILTER_B", value="100ohms", package="0402", P1=VOUTB, P2=_VOUTB_FILTERED)
-    Capacitor(name="C_FILTER_B", value="100pF", package="0402", P1=_VOUTB_FILTERED, P2=VSS)
-    VOUTB = _VOUTB_FILTERED
+    Resistor(name="R_FILTER_B", value="100ohms", package="0402", P1=_VOUTB_CHIP, P2=VOUTB)
+    Capacitor(name="C_FILTER_B", value="100pF", package="0402", P1=VOUTB, P2=VSS)
 
     # Channel C output filter
-    _VOUTC_FILTERED = Net("VOUTC_FILTERED")
-    Resistor(name="R_FILTER_C", value="100ohms", package="0402", P1=VOUTC, P2=_VOUTC_FILTERED)
-    Capacitor(name="C_FILTER_C", value="100pF", package="0402", P1=_VOUTC_FILTERED, P2=VSS)
-    VOUTC = _VOUTC_FILTERED
+    Resistor(name="R_FILTER_C", value="100ohms", package="0402", P1=_VOUTC_CHIP, P2=VOUTC)
+    Capacitor(name="C_FILTER_C", value="100pF", package="0402", P1=VOUTC, P2=VSS)
 
     # Channel D output filter
-    _VOUTD_FILTERED = Net("VOUTD_FILTERED")
-    Resistor(name="R_FILTER_D", value="100ohms", package="0402", P1=VOUTD, P2=_VOUTD_FILTERED)
-    Capacitor(name="C_FILTER_D", value="100pF", package="0402", P1=_VOUTD_FILTERED, P2=VSS)
-    VOUTD = _VOUTD_FILTERED
+    Resistor(name="R_FILTER_D", value="100ohms", package="0402", P1=_VOUTD_CHIP, P2=VOUTD)
+    Capacitor(name="C_FILTER_D", value="100pF", package="0402", P1=VOUTD, P2=VSS)
 
 # pcb:sch C_BULK.C x=766.0800 y=240.3000 rot=0
 # pcb:sch C_DEC.C x=664.4800 y=240.3000 rot=0

--- a/Battery_Management/DW01A.zen
+++ b/Battery_Management/DW01A.zen
@@ -48,12 +48,11 @@ BATT_MINUS = io("BATT-", Ground)  # Battery negative terminal
 BATT_INT = Net("BATT-INT")
 
 # Internal nets
-_VCC = Net("VCC")
-_GND = Net("GND")
+_VCC = Power("_VCC")
+_GND = Ground("_GND")
 _CS = Net("CS")
 _OD = Net("OD")
 _OC = Net("OC")
-_TD = Net("TD")
 
 
 # DW01A Battery Protection IC
@@ -61,7 +60,7 @@ Component(
     name="U1",
     symbol=Symbol(library="@kicad-symbols/Battery_Management.kicad_sym", name="DW01A"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-6.kicad_mod"),
-    pins={"VCC": _VCC, "GND": _GND, "OD": _OD, "OC": _OC, "CS": _CS, "TD": _TD},
+    pins={"VCC": _VCC, "GND": _GND, "OD": _OD, "OC": _OC, "CS": _CS},
 )
 
 # R1: 100Ω resistor from BATT+ to VCC

--- a/Battery_Management/LTC3553.zen
+++ b/Battery_Management/LTC3553.zen
@@ -52,14 +52,14 @@ if not enable_ldo and sequence_mode == SequenceMode("LDOFirst"):
 
 # External IO
 VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-BAT = io("BAT", Net, default=Net("BAT"))
+VOUT = io("VOUT", Power)
+BAT = io("BAT", Power)
 GND = io("GND", Ground)
-BUCK_OUT = io("BUCK_OUT", Net, default=Net("BUCK_OUT")) if enable_buck else None
-LDO_OUT = io("LDO_OUT", Net, default=Net("LDO_OUT")) if enable_ldo else None
-ON_BTN = io("ON_BTN", Net, default=Net("ON_BTN"))
-PBSTAT = io("PBSTAT", Net, default=Net("PBSTAT"))
-CHRG_STAT = io("CHRG_STAT", Net, default=Net("CHRG_STAT"))
+BUCK_OUT = io("BUCK_OUT", Power, optional=True) if enable_buck else None
+LDO_OUT = io("LDO_OUT", Power, optional=True) if enable_ldo else None
+ON_BTN = io("ON_BTN", Net)
+PBSTAT = io("PBSTAT", Net)
+CHRG_STAT = io("CHRG_STAT", Net)
 
 
 # Internal nets
@@ -69,7 +69,7 @@ _SEQ = VOUT if sequence_mode == SequenceMode("LDOFirst") else GND
 _STBY = Net("STBY")  # Standby mode control
 _BUCK_ON = VBUS if enable_buck else GND
 _LDO_ON = VOUT if enable_ldo else GND
-_SW = Net("SW") if enable_buck else None
+_SW = Power("SW") if enable_buck else None
 _BUCK_FB = Net("BUCK_FB") if enable_buck else None
 _LDO_FB = Net("LDO_FB") if enable_ldo else None
 _PROG = Net("PROG")

--- a/Battery_Management/LTC3553.zen
+++ b/Battery_Management/LTC3553.zen
@@ -17,7 +17,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/3
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -51,7 +50,7 @@ if not enable_ldo and sequence_mode == SequenceMode("LDOFirst"):
     error("LDOFirst sequence mode requires LDO to be enabled")
 
 # External IO
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 VOUT = io("VOUT", Power)
 BAT = io("BAT", Power)
 GND = io("GND", Ground)

--- a/Battery_Management/LTC3555.zen
+++ b/Battery_Management/LTC3555.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/3
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -119,7 +118,7 @@ add_external_ideal_diode = config("add_external_ideal_diode", bool, default=True
 add_charge_led = config("add_charge_led", bool, default=True)
 
 # External IO
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 VOUT = io("VOUT", Power)
 BAT = io("BAT", Power)
 GND = io("GND", Ground)

--- a/Battery_Management/LTC3555.zen
+++ b/Battery_Management/LTC3555.zen
@@ -58,6 +58,34 @@ VoltageConfig = enum(
     "0.800V",
 )
 
+
+# Feedback divider helper: VOUT = vfb * (1 + R_top / R_bot); uses 100k as R_bot.
+def _fb_top_ohms(vout, vfb):
+    _ratio = (vout / vfb) - 1
+    _r1k = 100 * _ratio
+    return str(int(_r1k)) + "kohm" if _r1k == int(_r1k) else str(_r1k) + "kohm"
+
+
+# Buck2/3 programmable FB-voltage table in I2C mode.
+_fb_voltage_by_config = {
+    VoltageConfig("0.425V"): 0.425,
+    VoltageConfig("0.450V"): 0.450,
+    VoltageConfig("0.475V"): 0.475,
+    VoltageConfig("0.500V"): 0.500,
+    VoltageConfig("0.525V"): 0.525,
+    VoltageConfig("0.550V"): 0.550,
+    VoltageConfig("0.575V"): 0.575,
+    VoltageConfig("0.600V"): 0.600,
+    VoltageConfig("0.625V"): 0.625,
+    VoltageConfig("0.650V"): 0.650,
+    VoltageConfig("0.675V"): 0.675,
+    VoltageConfig("0.700V"): 0.700,
+    VoltageConfig("0.725V"): 0.725,
+    VoltageConfig("0.750V"): 0.750,
+    VoltageConfig("0.775V"): 0.775,
+    VoltageConfig("0.800V"): 0.800,
+}
+
 # Configuration
 add_input_cap = config("add_input_cap", bool, default=True)
 add_output_cap = config("add_output_cap", bool, default=True)
@@ -92,49 +120,49 @@ add_charge_led = config("add_charge_led", bool, default=True)
 
 # External IO
 VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-BAT = io("BAT", Net, default=Net("BAT"))
+VOUT = io("VOUT", Power)
+BAT = io("BAT", Power)
 GND = io("GND", Ground)
 
 if enable_i2c:
-    i2c = io("I2C", I2c, default=I2c("I2C"))
-    DVCC = io("DVCC", Net, default=Net("DVCC"))
+    i2c = io("I2C", I2c)
+    DVCC = io("DVCC", Power)
 else:
     # Manual control pins
-    EN1 = io("EN1", Net, default=Net("EN1")) if enable_buck1 else None
-    EN2 = io("EN2", Net, default=Net("EN2")) if enable_buck2 else None
-    EN3 = io("EN3", Net, default=Net("EN3")) if enable_buck3 else None
-    ILIM0 = io("ILIM0", Net, default=Net("ILIM0"))
-    ILIM1 = io("ILIM1", Net, default=Net("ILIM1"))
+    EN1 = io("EN1", Net) if enable_buck1 else None
+    EN2 = io("EN2", Net) if enable_buck2 else None
+    EN3 = io("EN3", Net) if enable_buck3 else None
+    ILIM0 = io("ILIM0", Net)
+    ILIM1 = io("ILIM1", Net)
 
 # Buck outputs
-BUCK1_OUT = io("BUCK1_OUT", Net, default=Net("BUCK1_OUT")) if enable_buck1 else None
-BUCK2_OUT = io("BUCK2_OUT", Net, default=Net("BUCK2_OUT")) if enable_buck2 else None
-BUCK3_OUT = io("BUCK3_OUT", Net, default=Net("BUCK3_OUT")) if enable_buck3 else None
+BUCK1_OUT = io("BUCK1_OUT", Net) if enable_buck1 else None
+BUCK2_OUT = io("BUCK2_OUT", Net) if enable_buck2 else None
+BUCK3_OUT = io("BUCK3_OUT", Net) if enable_buck3 else None
 
 # Status outputs
-CHRG_STAT = io("CHRG_STAT", Net, default=Net("CHRG_STAT"))
-RST3 = io("RST3", Net, default=Net("RST3")) if enable_buck3 else None
+CHRG_STAT = io("CHRG_STAT", Net)
+RST3 = io("RST3", Net) if enable_buck3 else None
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _CLPROG = Net("CLPROG")
 _CLPROG_FILTER = Net("CLPROG_FILTER")  # Intermediate net for series connection
 _PROG = Net("PROG")
 _NTC = GND if not enable_ntc else Net("NTC")
 _GATE = Net("GATE") if add_external_ideal_diode else NotConnected()
-_LDO3V3 = Net("LDO3V3")
+_LDO3V3 = Power("LDO3V3")
 
 # Buck internal nets
-_SW1 = Net("SW1") if enable_buck1 else NotConnected()
+_SW1 = Power("SW1") if enable_buck1 else NotConnected()
 _FB1 = Net("FB1") if enable_buck1 else NotConnected()
 _VIN1 = VOUT if enable_buck1 else NotConnected()
 
-_SW2 = Net("SW2") if enable_buck2 else NotConnected()
+_SW2 = Power("SW2") if enable_buck2 else NotConnected()
 _FB2 = Net("FB2") if enable_buck2 else NotConnected()
 _VIN2 = VOUT if enable_buck2 else NotConnected()
 
-_SW3 = Net("SW3") if enable_buck3 else NotConnected()
+_SW3 = Power("SW3") if enable_buck3 else NotConnected()
 _FB3 = Net("FB3") if enable_buck3 else NotConnected()
 _VIN3 = VOUT if enable_buck3 else NotConnected()
 
@@ -296,11 +324,7 @@ if enable_buck1:
         # For voltages <= 0.8V, direct connection
         Resistor(name="R_FB1_TOP", value="0ohm", package="0402", P1=BUCK1_OUT, P2=_FB1)
     else:
-        ratio = (buck1_output_voltage / 0.8) - 1
-        # Using R2 = 100k as base
-        r1_value = 100 * ratio
-        r1_str = str(int(r1_value)) + "kohm" if r1_value == int(r1_value) else str(r1_value) + "kohm"
-        Resistor(name="R_FB1_TOP", value=r1_str, package="0402", P1=BUCK1_OUT, P2=_FB1)
+        Resistor(name="R_FB1_TOP", value=_fb_top_ohms(buck1_output_voltage, 0.8), package="0402", P1=BUCK1_OUT, P2=_FB1)
         Resistor(name="R_FB1_BOT", value="100kohm", package="0402", P1=_FB1, P2=GND)
 
     # Feedback compensation capacitor
@@ -321,35 +345,13 @@ if enable_buck2:
     # VOUT = VFB * (1 + R1/R2)
     if enable_i2c:
         # With I2C, FB can be programmed from 0.425V to 0.8V
-        # Get numeric value from VoltageConfig enum
-        fb_voltage_map = {
-            VoltageConfig("0.425V"): 0.425,
-            VoltageConfig("0.450V"): 0.450,
-            VoltageConfig("0.475V"): 0.475,
-            VoltageConfig("0.500V"): 0.500,
-            VoltageConfig("0.525V"): 0.525,
-            VoltageConfig("0.550V"): 0.550,
-            VoltageConfig("0.575V"): 0.575,
-            VoltageConfig("0.600V"): 0.600,
-            VoltageConfig("0.625V"): 0.625,
-            VoltageConfig("0.650V"): 0.650,
-            VoltageConfig("0.675V"): 0.675,
-            VoltageConfig("0.700V"): 0.700,
-            VoltageConfig("0.725V"): 0.725,
-            VoltageConfig("0.750V"): 0.750,
-            VoltageConfig("0.775V"): 0.775,
-            VoltageConfig("0.800V"): 0.800,
-        }
-        fb_voltage = fb_voltage_map.get(buck2_fb_voltage, 0.8)
+        _buck2_fb_v = _fb_voltage_by_config.get(buck2_fb_voltage, 0.8)
 
-        if buck2_output_voltage <= fb_voltage:
+        if buck2_output_voltage <= _buck2_fb_v:
             # For output <= FB voltage, direct connection
             Resistor(name="R_FB2_TOP", value="0ohm", package="0402", P1=BUCK2_OUT, P2=_FB2)
         else:
-            ratio = (buck2_output_voltage / fb_voltage) - 1
-            r1_value = 100 * ratio
-            r1_str = str(int(r1_value)) + "kohm" if r1_value == int(r1_value) else str(r1_value) + "kohm"
-            Resistor(name="R_FB2_TOP", value=r1_str, package="0402", P1=BUCK2_OUT, P2=_FB2)
+            Resistor(name="R_FB2_TOP", value=_fb_top_ohms(buck2_output_voltage, _buck2_fb_v), package="0402", P1=BUCK2_OUT, P2=_FB2)
             Resistor(name="R_FB2_BOT", value="100kohm", package="0402", P1=_FB2, P2=GND)
     else:
         # Without I2C, FB is fixed at 0.8V
@@ -357,10 +359,7 @@ if enable_buck2:
             # For voltages <= 0.8V, direct connection
             Resistor(name="R_FB2_TOP", value="0ohm", package="0402", P1=BUCK2_OUT, P2=_FB2)
         else:
-            ratio = (buck2_output_voltage / 0.8) - 1
-            r1_value = 100 * ratio
-            r1_str = str(int(r1_value)) + "kohm" if r1_value == int(r1_value) else str(r1_value) + "kohm"
-            Resistor(name="R_FB2_TOP", value=r1_str, package="0402", P1=BUCK2_OUT, P2=_FB2)
+            Resistor(name="R_FB2_TOP", value=_fb_top_ohms(buck2_output_voltage, 0.8), package="0402", P1=BUCK2_OUT, P2=_FB2)
             Resistor(name="R_FB2_BOT", value="100kohm", package="0402", P1=_FB2, P2=GND)
 
     # Feedback compensation capacitor
@@ -381,35 +380,13 @@ if enable_buck3:
     # VOUT = VFB * (1 + R1/R2)
     if enable_i2c:
         # With I2C, FB can be programmed from 0.425V to 0.8V
-        # Get numeric value from VoltageConfig enum
-        fb_voltage_map = {
-            VoltageConfig("0.425V"): 0.425,
-            VoltageConfig("0.450V"): 0.450,
-            VoltageConfig("0.475V"): 0.475,
-            VoltageConfig("0.500V"): 0.500,
-            VoltageConfig("0.525V"): 0.525,
-            VoltageConfig("0.550V"): 0.550,
-            VoltageConfig("0.575V"): 0.575,
-            VoltageConfig("0.600V"): 0.600,
-            VoltageConfig("0.625V"): 0.625,
-            VoltageConfig("0.650V"): 0.650,
-            VoltageConfig("0.675V"): 0.675,
-            VoltageConfig("0.700V"): 0.700,
-            VoltageConfig("0.725V"): 0.725,
-            VoltageConfig("0.750V"): 0.750,
-            VoltageConfig("0.775V"): 0.775,
-            VoltageConfig("0.800V"): 0.800,
-        }
-        fb_voltage = fb_voltage_map.get(buck3_fb_voltage, 0.8)
+        _buck3_fb_v = _fb_voltage_by_config.get(buck3_fb_voltage, 0.8)
 
-        if buck3_output_voltage <= fb_voltage:
+        if buck3_output_voltage <= _buck3_fb_v:
             # For output <= FB voltage, direct connection
             Resistor(name="R_FB3_TOP", value="0ohm", package="0402", P1=BUCK3_OUT, P2=_FB3)
         else:
-            ratio = (buck3_output_voltage / fb_voltage) - 1
-            r1_value = 100 * ratio
-            r1_str = str(int(r1_value)) + "kohm" if r1_value == int(r1_value) else str(r1_value) + "kohm"
-            Resistor(name="R_FB3_TOP", value=r1_str, package="0402", P1=BUCK3_OUT, P2=_FB3)
+            Resistor(name="R_FB3_TOP", value=_fb_top_ohms(buck3_output_voltage, _buck3_fb_v), package="0402", P1=BUCK3_OUT, P2=_FB3)
             Resistor(name="R_FB3_BOT", value="100kohm", package="0402", P1=_FB3, P2=GND)
     else:
         # Without I2C, FB is fixed at 0.8V
@@ -417,10 +394,7 @@ if enable_buck3:
             # For voltages <= 0.8V, direct connection
             Resistor(name="R_FB3_TOP", value="0ohm", package="0402", P1=BUCK3_OUT, P2=_FB3)
         else:
-            ratio = (buck3_output_voltage / 0.8) - 1
-            r1_value = 100 * ratio
-            r1_str = str(int(r1_value)) + "kohm" if r1_value == int(r1_value) else str(r1_value) + "kohm"
-            Resistor(name="R_FB3_TOP", value=r1_str, package="0402", P1=BUCK3_OUT, P2=_FB3)
+            Resistor(name="R_FB3_TOP", value=_fb_top_ohms(buck3_output_voltage, 0.8), package="0402", P1=BUCK3_OUT, P2=_FB3)
             Resistor(name="R_FB3_BOT", value="100kohm", package="0402", P1=_FB3, P2=GND)
 
     # Feedback compensation capacitor

--- a/Battery_Management/TP4057.zen
+++ b/Battery_Management/TP4057.zen
@@ -24,7 +24,6 @@ Datasheet: https://datasheet.lcsc.com/lcsc/2304140030_TOPPOWER-Nanjing-Extension
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # No longer using Power interface
 
@@ -61,7 +60,7 @@ if add_output_capacitor:
 add_test_points = config("add_test_points", bool, default=True, optional=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("4.5V to 9V"))
+VIN = io("VIN", Power(voltage="4.5V to 9V"))
 VBAT = io("VBAT", Power)
 GND = io("GND", Ground)
 

--- a/Battery_Management/TP4057.zen
+++ b/Battery_Management/TP4057.zen
@@ -76,9 +76,9 @@ else:
     _STDBY = Net("STDBY")
 
 # Internal nets
-_VCC = Net("VCC")
+_VCC = Power("VCC") if add_input_series_resistor else VIN
 _PROG = Net("PROG")
-_BAT = Net("BAT")
+_BAT = VBAT
 
 # Input protection and filtering
 if input_protection != InputProtection("None"):
@@ -92,12 +92,6 @@ if input_protection != InputProtection("None"):
 # Series input resistor for current limiting and thermal management
 if add_input_series_resistor:
     Resistor(name="R_IN", value=input_series_resistance, package="0805", P1=VIN, P2=_VCC)
-else:
-    # Direct connection
-    _VCC = VIN
-
-# Battery output connection - direct assignment
-_BAT = VBAT
 
 
 # Main TP4057 Component

--- a/Buffer/CDCV304.zen
+++ b/Buffer/CDCV304.zen
@@ -43,7 +43,7 @@ GND = io("GND", Ground)
 CLKIN = io("CLKIN", Net)
 
 # Internal nets
-_VDD_FILT = Net("VDD_FILT") if add_power_filtering else VDD
+_VDD_FILT = Power("VDD_FILT") if add_power_filtering else VDD
 
 # Output clocks
 CLK_OUT0 = io("CLK_OUT0", Net)

--- a/Display_Character/EA_T123X-I2C.zen
+++ b/Display_Character/EA_T123X-I2C.zen
@@ -60,7 +60,9 @@ if power_mode == PowerMode("SingleSupply"):
     _V0 = Power("V0") if add_contrast_circuit else VSS
     _VLCD = Net("VLCD") if add_contrast_circuit else VSS
 else:
-    _V0 = VDD
+    # DualSupply: V0 is driven by VDD only when the contrast divider is populated,
+    # otherwise leave it failsafe to VSS so the pin isn't tied to the supply rail.
+    _V0 = VDD if add_contrast_circuit else VSS
     _VLCD = Net("VLCD") if add_contrast_circuit else VSS
 
 # Main display component - based on pinout table

--- a/Display_Character/EA_T123X-I2C.zen
+++ b/Display_Character/EA_T123X-I2C.zen
@@ -56,8 +56,12 @@ VSS = io("VSS", Ground)
 i2c = io("I2C", I2c)
 
 # Internal nets for contrast
-_V0 = Net("V0") if power_mode == PowerMode("SingleSupply") else VDD
-_VLCD = Net("VLCD")
+if power_mode == PowerMode("SingleSupply"):
+    _V0 = Power("V0") if add_contrast_circuit else VSS
+    _VLCD = Net("VLCD") if add_contrast_circuit else VSS
+else:
+    _V0 = VDD
+    _VLCD = Net("VLCD") if add_contrast_circuit else VSS
 
 # Main display component - based on pinout table
 Component(
@@ -140,9 +144,8 @@ if add_contrast_circuit:
 
 else:
     # Contrast circuit is mandatory - provide minimal connections
-    # V0 and VLCD must not float
-    _V0 = VSS  # Connect to ground as failsafe
-    _VLCD = VSS
+    # V0 and VLCD must not float; handled above when add_contrast_circuit is False.
+    pass
 
 # Test points
 if add_test_points:

--- a/Display_Graphic/EA_DOGL128X-6.zen
+++ b/Display_Graphic/EA_DOGL128X-6.zen
@@ -112,19 +112,19 @@ if add_backlight and backlight_config != BacklightConfig("External") and backlig
     if backlight_config == BacklightConfig("Series"):
         # Series connection of 3 LED segments
         _LED_A1 = VDD
-        _LED_K1 = Net("LED_K1")  # Intermediate connection to A2
+        _LED_K1 = Power("LED_K1")  # Intermediate connection to A2
         _LED_A2 = _LED_K1  # Connect K1 to A2
-        _LED_K2 = Net("LED_K2")  # Intermediate connection to A3
+        _LED_K2 = Power("LED_K2")  # Intermediate connection to A3
         _LED_A3 = _LED_K2  # Connect K2 to A3
-        _LED_K3 = Net("LED_K3")  # Final cathode to resistor
+        _LED_K3 = Power("LED_K3")  # Final cathode to resistor
     else:  # Parallel configuration
         # Parallel connection of 3 LED segments
         _LED_A1 = VDD
         _LED_A2 = VDD
         _LED_A3 = VDD
-        _LED_K1 = Net("LED_K1")
-        _LED_K2 = Net("LED_K2")
-        _LED_K3 = Net("LED_K3")
+        _LED_K1 = Power("LED_K1")
+        _LED_K2 = Power("LED_K2")
+        _LED_K3 = Power("LED_K3")
 else:
     # Not using internal backlight - assign NC nets
     _LED_A1 = NotConnected()
@@ -232,21 +232,17 @@ if add_backlight and backlight_config != BacklightConfig("External") and backlig
             Resistor(name="R_LED_EXT", value="10kohms", package="0603", P1=_LED_K3, P2=GND)
         else:
             # Calculate resistance for lower voltage LEDs
-            r_value = int((3.3 - 3 * vf_typical) / (backlight_current_ma / 1000.0))
-            if r_value < 10:  # Minimum 10 ohms for safety
-                r_value = 10
-            Resistor(name="R_LED", value=f"{r_value}ohms", package="0603", P1=_LED_K3, P2=GND)
+            _r_series = max(10, int((3.3 - 3 * vf_typical) / (backlight_current_ma / 1000.0)))
+            Resistor(name="R_LED", value=f"{_r_series}ohms", package="0603", P1=_LED_K3, P2=GND)
 
     else:  # Parallel configuration
         # Individual current limiting resistors
         # R = (VDD - Vf) / I
-        r_value = int((3.3 - vf_typical) / (backlight_current_ma / 1000.0 / 3))  # Divide current by 3
-        if r_value < 10:  # Minimum 10 ohms for safety
-            r_value = 10
+        _r_parallel = max(10, int((3.3 - vf_typical) / (backlight_current_ma / 1000.0 / 3)))  # Divide current by 3
 
-        Resistor(name="R_LED1", value=f"{r_value}ohms", package="0402", P1=_LED_K1, P2=GND)
-        Resistor(name="R_LED2", value=f"{r_value}ohms", package="0402", P1=_LED_K2, P2=GND)
-        Resistor(name="R_LED3", value=f"{r_value}ohms", package="0402", P1=_LED_K3, P2=GND)
+        Resistor(name="R_LED1", value=f"{_r_parallel}ohms", package="0402", P1=_LED_K1, P2=GND)
+        Resistor(name="R_LED2", value=f"{_r_parallel}ohms", package="0402", P1=_LED_K2, P2=GND)
+        Resistor(name="R_LED3", value=f"{_r_parallel}ohms", package="0402", P1=_LED_K3, P2=GND)
 
 # Test points
 if add_test_points:

--- a/Display_Graphic/EA_DOGL128X-6.zen
+++ b/Display_Graphic/EA_DOGL128X-6.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.lcd-module.de/eng/pdf/grafik/dogl128-6e.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -59,7 +58,7 @@ if add_backlight:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("3V to 3.3V"))
+VDD = io("VDD", Power(voltage="3V to 3.3V"))
 GND = io("GND", Ground)
 
 # SPI Interface

--- a/Driver_LED/PCA9685BS.zen
+++ b/Driver_LED/PCA9685BS.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -125,7 +124,7 @@ add_led_header = config("add_led_header", bool, default=True)
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.3V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.3V to 5.5V"))
 VSS = io("VSS", Ground)
 
 # I2C interface

--- a/Driver_LED/PCA9685BS.zen
+++ b/Driver_LED/PCA9685BS.zen
@@ -178,16 +178,8 @@ if expose_address_pins:
     _A4 = A4
     _A5 = A5
 else:
-    # Internal nets for address pins (will be assigned in address configuration)
-    pass
-
-# Address configuration
-if not expose_address_pins:
-    # Set address pins based on configuration
-    # The PCA9685 base address is 0x40, with A0-A5 pins adding to this base
-    # A0=1 adds 0x01, A1=1 adds 0x02, A2=1 adds 0x04, A3=1 adds 0x08, A4=1 adds 0x10, A5=1 adds 0x20
-    # Map address enum to integer value
-    address_map = {
+    # Hard-strap address pins based on `address` config (base 0x40; A0..A5 set bits).
+    _address_map = {
         I2cAddress("0x40"): 0x40,
         I2cAddress("0x41"): 0x41,
         I2cAddress("0x42"): 0x42,
@@ -253,17 +245,13 @@ if not expose_address_pins:
         I2cAddress("0x7E"): 0x7E,
         I2cAddress("0x7F"): 0x7F,
     }
-
-    # Extract address bits from address value
-    addr_val = address_map[address] & 0x3F  # Get lower 6 bits
-
-    # Connect each address pin to VDD or VSS using conditional net assignment
-    _A0 = VDD if addr_val & 0x01 else VSS
-    _A1 = VDD if addr_val & 0x02 else VSS
-    _A2 = VDD if addr_val & 0x04 else VSS
-    _A3 = VDD if addr_val & 0x08 else VSS
-    _A4 = VDD if addr_val & 0x10 else VSS
-    _A5 = VDD if addr_val & 0x20 else VSS
+    _addr_val = _address_map[address] & 0x3F
+    _A0 = VDD if _addr_val & 0x01 else VSS
+    _A1 = VDD if _addr_val & 0x02 else VSS
+    _A2 = VDD if _addr_val & 0x04 else VSS
+    _A3 = VDD if _addr_val & 0x08 else VSS
+    _A4 = VDD if _addr_val & 0x10 else VSS
+    _A5 = VDD if _addr_val & 0x20 else VSS
 
 # External clock handling
 if clock_source == ClockSource("External"):

--- a/Driver_LED/PCA9685PW.zen
+++ b/Driver_LED/PCA9685PW.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -125,7 +124,7 @@ add_led_header = config("add_led_header", bool, default=True)
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.3V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.3V to 5.5V"))
 VSS = io("VSS", Ground)
 
 # I2C interface

--- a/Driver_LED/PCA9685PW.zen
+++ b/Driver_LED/PCA9685PW.zen
@@ -178,18 +178,8 @@ if expose_address_pins:
     _A4 = A4
     _A5 = A5
 else:
-    # Internal nets for address pins (will be assigned in address configuration)
-    pass
-
-# No internal LED nets needed - direct connection
-
-# Address configuration
-if not expose_address_pins:
-    # Set address pins based on configuration
-    # The PCA9685 base address is 0x40, with A0-A5 pins adding to this base
-    # A0=1 adds 0x01, A1=1 adds 0x02, A2=1 adds 0x04, A3=1 adds 0x08, A4=1 adds 0x10, A5=1 adds 0x20
-    # Map address enum to integer value
-    address_map = {
+    # Hard-strap address pins based on `address` config (base 0x40; A0..A5 set bits).
+    _address_map = {
         I2cAddress("0x40"): 0x40,
         I2cAddress("0x41"): 0x41,
         I2cAddress("0x42"): 0x42,
@@ -255,17 +245,15 @@ if not expose_address_pins:
         I2cAddress("0x7E"): 0x7E,
         I2cAddress("0x7F"): 0x7F,
     }
+    _addr_val = _address_map[address] & 0x3F
+    _A0 = VDD if _addr_val & 0x01 else VSS
+    _A1 = VDD if _addr_val & 0x02 else VSS
+    _A2 = VDD if _addr_val & 0x04 else VSS
+    _A3 = VDD if _addr_val & 0x08 else VSS
+    _A4 = VDD if _addr_val & 0x10 else VSS
+    _A5 = VDD if _addr_val & 0x20 else VSS
 
-    # Extract address bits from address value
-    addr_val = address_map[address] & 0x3F  # Get lower 6 bits
-
-    # Connect each address pin to VDD or VSS using conditional net assignment
-    _A0 = VDD if addr_val & 0x01 else VSS
-    _A1 = VDD if addr_val & 0x02 else VSS
-    _A2 = VDD if addr_val & 0x04 else VSS
-    _A3 = VDD if addr_val & 0x08 else VSS
-    _A4 = VDD if addr_val & 0x10 else VSS
-    _A5 = VDD if addr_val & 0x20 else VSS
+# No internal LED nets needed - direct connection
 
 # External clock handling
 if clock_source == ClockSource("External"):

--- a/Driver_LED/TPS61165DBV.zen
+++ b/Driver_LED/TPS61165DBV.zen
@@ -83,20 +83,22 @@ circuit_mode = config("circuit_mode", CircuitMode, default="Typical")
 # External IO
 VDD = io("VDD", Power, checks=voltage_within("3V to 18V"))
 GND = io("GND", Ground)
-LED_ANODE = io("LED_ANODE", Net, default=Net("LED_ANODE"))
-LED_CATHODE = io("LED_CATHODE", Net, default=Net("LED_CATHODE"))
+LED_ANODE = io("LED_ANODE", Net)
+LED_CATHODE = io("LED_CATHODE", Net)
 
 # Control input - external pin for user control
-CTRL = io("CTRL", Net, default=Net("CTRL"))
+CTRL = io("CTRL", Net)
 
 # PWM input for external PWM dimming network
 if circuit_mode == CircuitMode("ExternalPWM"):
-    PWM_IN = io("PWM_IN", Net, default=Net("PWM_IN"))
+    PWM_IN = io("PWM_IN", Net)
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _COMP = Net("COMP")
-_FB = Net("FB")
+# In Typical mode, LED_CATHODE ties directly to the FB pin for current sensing.
+# In ExternalPWM mode, FB is driven by a divider network from LED_CATHODE/PWM_IN.
+_FB = LED_CATHODE if circuit_mode == CircuitMode("Typical") else Net("FB")
 
 # Main component - High-Brightness White LED Driver
 Component(
@@ -108,29 +110,23 @@ Component(
 
 # Current sense resistor calculation based on LED current
 # I_LED = V_FB / R_SET, where V_FB = 200mV
-if led_current == LEDCurrent("20mA"):
-    r_set_value = "10ohms"
-elif led_current == LEDCurrent("50mA"):
-    r_set_value = "4ohms"
-elif led_current == LEDCurrent("100mA"):
-    r_set_value = "2ohms"
-elif led_current == LEDCurrent("150mA"):
-    r_set_value = "1.33ohms"
-elif led_current == LEDCurrent("200mA"):
-    r_set_value = "1ohms"
-elif led_current == LEDCurrent("300mA"):
-    r_set_value = "0.68ohms"
-else:  # 350mA
-    r_set_value = "0.57ohms"
+# In ExternalPWM mode the datasheet recommends RSET = 0.64 ohm.
+_r_set_by_current = {
+    LEDCurrent("20mA"): "10ohms",
+    LEDCurrent("50mA"): "4ohms",
+    LEDCurrent("100mA"): "2ohms",
+    LEDCurrent("150mA"): "1.33ohms",
+    LEDCurrent("200mA"): "1ohms",
+    LEDCurrent("300mA"): "0.68ohms",
+    LEDCurrent("350mA"): "0.57ohms",
+}
+r_set_value = "0.64ohms" if circuit_mode == CircuitMode("ExternalPWM") else _r_set_by_current[led_current]
 
 # Current sensing configuration depends on circuit mode
 if circuit_mode == CircuitMode("ExternalPWM"):
     # External PWM dimming network with resistor divider
     # Create internal net for divider point
     _DIVIDER = Net("DIVIDER")
-
-    # Adjust RSET for external PWM dimming (typical value from datasheet)
-    r_set_value = "0.64ohms"
 
     # R1: 10kΩ from LED cathode to FB pin
     Resistor(name="R1_PWM", value="10kohms", package="0603", P1=LED_CATHODE, P2=_FB)
@@ -147,12 +143,8 @@ if circuit_mode == CircuitMode("ExternalPWM"):
     # RSET connects between LED cathode and ground
     Resistor(name="R_SET", value=r_set_value, package="0805", P1=LED_CATHODE, P2=GND)
 else:
-    # Standard current sense configuration
-    # Connect between FB (which connects to LED cathode) and GND
+    # Standard current sense: R_SET from FB (== LED_CATHODE) to GND
     Resistor(name="R_SET", value=r_set_value, package="0805", P1=_FB, P2=GND)
-
-    # Connect LED cathode to FB pin for current sensing
-    LED_CATHODE = _FB
 
 # Circuit topology summary:
 # Typical:  VDD -> L1 -> SW -> D1 -> LED_ANODE -> LEDs -> LED_CATHODE -> FB -> R_SET -> GND

--- a/Driver_LED/TPS61165DBV.zen
+++ b/Driver_LED/TPS61165DBV.zen
@@ -48,7 +48,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/tps61165.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -81,7 +80,7 @@ else:
 circuit_mode = config("circuit_mode", CircuitMode, default="Typical")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("3V to 18V"))
+VDD = io("VDD", Power(voltage="3V to 18V"))
 GND = io("GND", Ground)
 LED_ANODE = io("LED_ANODE", Net)
 LED_CATHODE = io("LED_CATHODE", Net)

--- a/Driver_LED/TPS61165DBV.zen
+++ b/Driver_LED/TPS61165DBV.zen
@@ -96,9 +96,9 @@ if circuit_mode == CircuitMode("ExternalPWM"):
 # Internal nets
 _SW = Power("SW")
 _COMP = Net("COMP")
-# In Typical mode, LED_CATHODE ties directly to the FB pin for current sensing.
+# In Typical and SEPIC modes, LED_CATHODE ties directly to the FB pin for current sensing.
 # In ExternalPWM mode, FB is driven by a divider network from LED_CATHODE/PWM_IN.
-_FB = LED_CATHODE if circuit_mode == CircuitMode("Typical") else Net("FB")
+_FB = Net("FB") if circuit_mode == CircuitMode("ExternalPWM") else LED_CATHODE
 
 # Main component - High-Brightness White LED Driver
 Component(

--- a/Interface_Expansion/LTC4317.zen
+++ b/Interface_Expansion/LTC4317.zen
@@ -122,9 +122,9 @@ if channel_config == ChannelConfig("Both") or channel_config == ChannelConfig("C
         xorh2_r_top, xorh2_r_bottom = get_xorh_resistors(xorh2_config.value)
 
 # External IO
-i2c_in = io("I2C_IN", I2c, default=I2c("I2C_IN"))
-i2c_out1 = io("I2C_OUT1", I2c, default=I2c("I2C_OUT1")) if channel_config != ChannelConfig("Channel2Only") else None
-i2c_out2 = io("I2C_OUT2", I2c, default=I2c("I2C_OUT2")) if channel_config != ChannelConfig("Channel1Only") else None
+i2c_in = io("I2C_IN", I2c)
+i2c_out1 = io("I2C_OUT1", I2c) if channel_config != ChannelConfig("Channel2Only") else None
+i2c_out2 = io("I2C_OUT2", I2c) if channel_config != ChannelConfig("Channel1Only") else None
 
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
@@ -132,17 +132,17 @@ GND = io("GND", Ground)
 # ENABLE pins - Fixed logic to avoid conflicts
 if channel_config == ChannelConfig("Channel2Only"):
     ENABLE1 = VCC  # Channel 1 not used, always enabled
-    ENABLE2 = io("ENABLE2", Net, default=Net("ENABLE2")) if enable_control else VCC
+    ENABLE2 = io("ENABLE2", Net) if enable_control else VCC
 elif channel_config == ChannelConfig("Channel1Only"):
-    ENABLE1 = io("ENABLE1", Net, default=Net("ENABLE1")) if enable_control else VCC
+    ENABLE1 = io("ENABLE1", Net) if enable_control else VCC
     ENABLE2 = VCC  # Channel 2 not used, always enabled
 else:  # Both channels
-    ENABLE1 = io("ENABLE1", Net, default=Net("ENABLE1")) if enable_control else VCC
-    ENABLE2 = io("ENABLE2", Net, default=Net("ENABLE2")) if enable_control else VCC
+    ENABLE1 = io("ENABLE1", Net) if enable_control else VCC
+    ENABLE2 = io("ENABLE2", Net) if enable_control else VCC
 
 # READY pins
-READY1 = io("READY1", Net, default=Net("READY1")) if channel_config != ChannelConfig("Channel2Only") else NotConnected()
-READY2 = io("READY2", Net, default=Net("READY2")) if channel_config != ChannelConfig("Channel1Only") else NotConnected()
+READY1 = io("READY1", Net) if channel_config != ChannelConfig("Channel2Only") else NotConnected()
+READY2 = io("READY2", Net) if channel_config != ChannelConfig("Channel1Only") else NotConnected()
 
 # Internal nets for XOR configuration - handle Open/Short cases
 # Channel 1 nets

--- a/Interface_Expansion/PCA9548ADB.zen
+++ b/Interface_Expansion/PCA9548ADB.zen
@@ -86,10 +86,21 @@ if expose_address_pins:
     _A1 = A1
     _A2 = A2
 else:
-    # Internal nets for address pins
-    _A0 = Net("A0")
-    _A1 = Net("A1")
-    _A2 = Net("A2")
+    # Hard-strap address pins to VCC/GND based on `address` config.
+    _address_map = {
+        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
+        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
+        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
+        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
+        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
+        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
+        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
+        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
+    }
+    _a2_high, _a1_high, _a0_high = _address_map[address]
+    _A0 = VCC if _a0_high else GND
+    _A1 = VCC if _a1_high else GND
+    _A2 = VCC if _a2_high else GND
 
 # Create nets for all channels (some may not be exposed)
 _SC = [Net(f"SC{i}") for i in range(8)]
@@ -105,27 +116,6 @@ for ch in range(8):
     if ch not in enabled_channels:
         io(f"SC{ch}", Net, default=_SC[ch])
         io(f"SD{ch}", Net, default=_SD[ch])
-
-# Address configuration
-if not expose_address_pins:
-    # Map address to pin states
-    address_map = {
-        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
-        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
-        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
-        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
-        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
-        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
-        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
-        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
-    }
-
-    a2_high, a1_high, a0_high = address_map[address]
-
-    # Connect address pins
-    _A0 = VCC if a0_high else GND
-    _A1 = VCC if a1_high else GND
-    _A2 = VCC if a2_high else GND
 
 # Main component
 Component(

--- a/Interface_Expansion/PCA9548ADB.zen
+++ b/Interface_Expansion/PCA9548ADB.zen
@@ -17,7 +17,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/pca9548a.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ enabled_channels = config("enabled_channels", list, default=[0, 1, 2, 3, 4, 5, 6
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.3V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.3V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C upstream interface

--- a/Interface_Expansion/PCA9548ADW.zen
+++ b/Interface_Expansion/PCA9548ADW.zen
@@ -86,10 +86,21 @@ if expose_address_pins:
     _A1 = A1
     _A2 = A2
 else:
-    # Internal nets for address pins
-    _A0 = Net("A0")
-    _A1 = Net("A1")
-    _A2 = Net("A2")
+    # Hard-strap address pins to VCC/GND based on `address` config.
+    _address_map = {
+        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
+        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
+        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
+        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
+        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
+        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
+        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
+        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
+    }
+    _a2_high, _a1_high, _a0_high = _address_map[address]
+    _A0 = VCC if _a0_high else GND
+    _A1 = VCC if _a1_high else GND
+    _A2 = VCC if _a2_high else GND
 
 # Create nets for all channels (some may not be exposed)
 _SC = [Net(f"SC{i}") for i in range(8)]
@@ -105,27 +116,6 @@ for ch in range(8):
     if ch not in enabled_channels:
         io(f"SC{ch}", Net, default=_SC[ch])
         io(f"SD{ch}", Net, default=_SD[ch])
-
-# Address configuration
-if not expose_address_pins:
-    # Map address to pin states
-    address_map = {
-        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
-        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
-        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
-        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
-        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
-        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
-        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
-        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
-    }
-
-    a2_high, a1_high, a0_high = address_map[address]
-
-    # Connect address pins
-    _A0 = VCC if a0_high else GND
-    _A1 = VCC if a1_high else GND
-    _A2 = VCC if a2_high else GND
 
 # Main component
 Component(

--- a/Interface_Expansion/PCA9548ADW.zen
+++ b/Interface_Expansion/PCA9548ADW.zen
@@ -17,7 +17,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/pca9548a.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ enabled_channels = config("enabled_channels", list, default=[0, 1, 2, 3, 4, 5, 6
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.3V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.3V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C upstream interface

--- a/Interface_Expansion/PCA9548APW.zen
+++ b/Interface_Expansion/PCA9548APW.zen
@@ -86,10 +86,21 @@ if expose_address_pins:
     _A1 = A1
     _A2 = A2
 else:
-    # Internal nets for address pins
-    _A0 = Net("A0")
-    _A1 = Net("A1")
-    _A2 = Net("A2")
+    # Hard-strap address pins to VCC/GND based on `address` config.
+    _address_map = {
+        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
+        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
+        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
+        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
+        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
+        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
+        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
+        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
+    }
+    _a2_high, _a1_high, _a0_high = _address_map[address]
+    _A0 = VCC if _a0_high else GND
+    _A1 = VCC if _a1_high else GND
+    _A2 = VCC if _a2_high else GND
 
 # Create nets for all channels (some may not be exposed)
 _SC = [Net(f"SC{i}") for i in range(8)]
@@ -105,27 +116,6 @@ for ch in range(8):
     if ch not in enabled_channels:
         io(f"SC{ch}", Net, default=_SC[ch])
         io(f"SD{ch}", Net, default=_SD[ch])
-
-# Address configuration
-if not expose_address_pins:
-    # Map address to pin states
-    address_map = {
-        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
-        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
-        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
-        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
-        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
-        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
-        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
-        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
-    }
-
-    a2_high, a1_high, a0_high = address_map[address]
-
-    # Connect address pins
-    _A0 = VCC if a0_high else GND
-    _A1 = VCC if a1_high else GND
-    _A2 = VCC if a2_high else GND
 
 # Main component
 Component(

--- a/Interface_Expansion/PCA9548APW.zen
+++ b/Interface_Expansion/PCA9548APW.zen
@@ -17,7 +17,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/pca9548a.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ enabled_channels = config("enabled_channels", list, default=[0, 1, 2, 3, 4, 5, 6
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.3V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.3V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C upstream interface

--- a/Interface_Expansion/PCA9548ARGE.zen
+++ b/Interface_Expansion/PCA9548ARGE.zen
@@ -17,7 +17,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/pca9548a.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ enabled_channels = config("enabled_channels", list, default=[0, 1, 2, 3, 4, 5, 6
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.3V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.3V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C upstream interface

--- a/Interface_Expansion/PCA9548ARGE.zen
+++ b/Interface_Expansion/PCA9548ARGE.zen
@@ -86,10 +86,21 @@ if expose_address_pins:
     _A1 = A1
     _A2 = A2
 else:
-    # Internal nets for address pins
-    _A0 = Net("A0")
-    _A1 = Net("A1")
-    _A2 = Net("A2")
+    # Hard-strap address pins to VCC/GND based on `address` config.
+    _address_map = {
+        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
+        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
+        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
+        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
+        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
+        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
+        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
+        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
+    }
+    _a2_high, _a1_high, _a0_high = _address_map[address]
+    _A0 = VCC if _a0_high else GND
+    _A1 = VCC if _a1_high else GND
+    _A2 = VCC if _a2_high else GND
 
 # Create nets for all channels (some may not be exposed)
 _SC = [Net(f"SC{i}") for i in range(8)]
@@ -105,27 +116,6 @@ for ch in range(8):
     if ch not in enabled_channels:
         io(f"SC{ch}", Net, default=_SC[ch])
         io(f"SD{ch}", Net, default=_SD[ch])
-
-# Address configuration
-if not expose_address_pins:
-    # Map address to pin states
-    address_map = {
-        AddressConfig("0x70"): (False, False, False),  # A2=L, A1=L, A0=L
-        AddressConfig("0x71"): (False, False, True),  # A2=L, A1=L, A0=H
-        AddressConfig("0x72"): (False, True, False),  # A2=L, A1=H, A0=L
-        AddressConfig("0x73"): (False, True, True),  # A2=L, A1=H, A0=H
-        AddressConfig("0x74"): (True, False, False),  # A2=H, A1=L, A0=L
-        AddressConfig("0x75"): (True, False, True),  # A2=H, A1=L, A0=H
-        AddressConfig("0x76"): (True, True, False),  # A2=H, A1=H, A0=L
-        AddressConfig("0x77"): (True, True, True),  # A2=H, A1=H, A0=H
-    }
-
-    a2_high, a1_high, a0_high = address_map[address]
-
-    # Connect address pins
-    _A0 = VCC if a0_high else GND
-    _A1 = VCC if a1_high else GND
-    _A2 = VCC if a2_high else GND
 
 # Main component
 Component(
@@ -159,7 +149,6 @@ Component(
         "SCL": i2c_upstream.SCL,
         "SDA": i2c_upstream.SDA,
         "VCC": VCC,
-        "1EP": GND,
     },
 )
 

--- a/Interface_Expansion/TCA9535MRGER.zen
+++ b/Interface_Expansion/TCA9535MRGER.zen
@@ -94,25 +94,19 @@ else:
     INT = Net("INT_NC")  # Not connected internally
 
 # GPIO ports - conditionally exposed based on port configuration
-# Create internal nets for all GPIO pins
-_gpio_p0 = [Net(f"P0{i}") for i in range(8)]
-_gpio_p1 = [Net(f"P1{i}") for i in range(8)]
-
-# Expose active ports as external IOs
+# Create internal nets for unused pins only; exposed pins use external IOs.
 if port_config == PortConfig("Port0Only") or port_config == PortConfig("BothPorts"):
     gpio_p0 = [io(f"P0{i}", Net) for i in range(8)]
-    # Connect internal nets to external IOs
-    for i in range(8):
-        _gpio_p0[i] = gpio_p0[i]
+    _gpio_p0 = gpio_p0
 else:
+    _gpio_p0 = [Net(f"P0{i}") for i in range(8)]
     gpio_p0 = _gpio_p0  # Port 0 not exposed, use internal nets
 
 if port_config == PortConfig("Port1Only") or port_config == PortConfig("BothPorts"):
     gpio_p1 = [io(f"P1{i}", Net) for i in range(8)]
-    # Connect internal nets to external IOs
-    for i in range(8):
-        _gpio_p1[i] = gpio_p1[i]
+    _gpio_p1 = gpio_p1
 else:
+    _gpio_p1 = [Net(f"P1{i}") for i in range(8)]
     gpio_p1 = _gpio_p1  # Port 1 not exposed, use internal nets
 
 # Address configuration nets

--- a/Interface_Expansion/TCA9535MRGER.zen
+++ b/Interface_Expansion/TCA9535MRGER.zen
@@ -100,7 +100,7 @@ _gpio_p1 = [Net(f"P1{i}") for i in range(8)]
 
 # Expose active ports as external IOs
 if port_config == PortConfig("Port0Only") or port_config == PortConfig("BothPorts"):
-    gpio_p0 = [io(f"P0{i}", Net, default=_gpio_p0[i]) for i in range(8)]
+    gpio_p0 = [io(f"P0{i}", Net) for i in range(8)]
     # Connect internal nets to external IOs
     for i in range(8):
         _gpio_p0[i] = gpio_p0[i]
@@ -108,7 +108,7 @@ else:
     gpio_p0 = _gpio_p0  # Port 0 not exposed, use internal nets
 
 if port_config == PortConfig("Port1Only") or port_config == PortConfig("BothPorts"):
-    gpio_p1 = [io(f"P1{i}", Net, default=_gpio_p1[i]) for i in range(8)]
+    gpio_p1 = [io(f"P1{i}", Net) for i in range(8)]
     # Connect internal nets to external IOs
     for i in range(8):
         _gpio_p1[i] = gpio_p1[i]

--- a/Interface_Expansion/TCA9535MRGER.zen
+++ b/Interface_Expansion/TCA9535MRGER.zen
@@ -33,7 +33,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/tca9535.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -81,7 +80,7 @@ if add_unused_io_resistors or unused_port_handling == UnusedPortHandling("PullUp
 add_test_points = config("add_test_points", bool, default=True, optional=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("1.65V to 5.5V"))
+VCC = io("VCC", Power(voltage="1.65V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Interface_UART/ISL3172E.zen
+++ b/Interface_UART/ISL3172E.zen
@@ -57,15 +57,14 @@ DE = io("DE", Net)
 DI = io("DI", Net)
 
 # Internal nets
-_RE_INT = Net("RE_INT") if re_pulldown else RE
-_DE_INT = Net("DE_INT") if de_pullup else DE
+# (External RE/DE are used directly; pull resistors attach to them.)
 
 # Main transceiver component
 Component(
     name="ISL3172E",
     symbol=Symbol(library="@kicad-symbols/Interface_UART.kicad_sym", name="ISL3172E"),
     footprint=File("@kicad-footprints/Package_SO.pretty/SOIC-8_3.9x4.9mm_P1.27mm.kicad_mod"),
-    pins={"RO": RO, "~{RE}": _RE_INT, "DE": _DE_INT, "DI": DI, "VCC": VCC, "GND": GND, "A": RS485_A, "B": RS485_B},
+    pins={"RO": RO, "~{RE}": RE, "DE": DE, "DI": DI, "VCC": VCC, "GND": GND, "A": RS485_A, "B": RS485_B},
 )
 
 # Power supply decoupling - as per datasheet Figure 1
@@ -78,15 +77,11 @@ if add_decoupling_caps:
 # Control signal pull resistors
 if re_pulldown:
     # RE is active low - pull down for receive enable by default (1k to 3k per datasheet)
-    Resistor(name="R_RE_PD", value=re_pulldown_value, package="0402", P1=_RE_INT, P2=GND)
-    # Connect internal net to external
-    _RE_INT = RE
+    Resistor(name="R_RE_PD", value=re_pulldown_value, package="0402", P1=RE, P2=GND)
 
 if de_pullup:
     # DE is active high - pull up through resistor for transmit enable (1k to 3k per datasheet)
-    Resistor(name="R_DE_PU", value=de_pullup_value, package="0402", P1=_DE_INT, P2=VCC)
-    # Connect internal net to external
-    _DE_INT = DE
+    Resistor(name="R_DE_PU", value=de_pullup_value, package="0402", P1=DE, P2=VCC)
 
 # Bus termination
 Resistor(

--- a/Interface_USB/AP33771.zen
+++ b/Interface_USB/AP33771.zen
@@ -54,17 +54,17 @@ add_power_led = config("add_power_led", bool, default=True)
 
 
 # External IO
-CC1 = io("CC1", Net, default=Net("CC1"))
-CC2 = io("CC2", Net, default=Net("CC2"))
-VBUS_IN = io("VBUS_IN", Net, default=Net("VBUS_IN"))
-VBUS_OUT = io("VBUS_OUT", Net, default=Net("VBUS_OUT"))
-PWR_EN = io("PWR_EN", Net, default=Net("PWR_EN"))
+CC1 = io("CC1", Net)
+CC2 = io("CC2", Net)
+VBUS_IN = io("VBUS_IN", Power)
+VBUS_OUT = io("VBUS_OUT", Power)
+PWR_EN = io("PWR_EN", Power)
 GND = io("GND", Ground)
 
 # Internal nets
-_VCC = Net("VCC")
-_V5V = Net("V5V")
-_V3VD = Net("V3VD")
+_VCC = Power("VCC")
+_V5V = Power("V5V")
+_V3VD = Power("V3VD")
 _VSEL0 = Net("VSEL0")
 _VSEL1 = Net("VSEL1")
 _VSEL2 = Net("VSEL2")
@@ -74,8 +74,7 @@ _IFB = Net("IFB")
 _ISENP = VBUS_IN
 _GPIO1 = Net("GPIO1")
 _GPIO4 = Net("GPIO4")
-_NC = NotConnected()
-_VBUS = Net("VBUS")  # Internal VBUS net for chip
+_VBUS = Power("VBUS")  # Internal VBUS net for chip
 
 
 # Voltage selection configuration (VSEL2, VSEL1, VSEL0)
@@ -106,7 +105,6 @@ Component(
         "VSEL1": _VSEL1,
         "VSEL2": _VSEL2,
         "PSEL": _PSEL,
-        "NC": _NC,
         "VCC": _VCC,
         "GND": GND,
         "PWR_EN": PWR_EN,

--- a/Interface_USB/AP33771.zen
+++ b/Interface_USB/AP33771.zen
@@ -58,7 +58,7 @@ CC1 = io("CC1", Net)
 CC2 = io("CC2", Net)
 VBUS_IN = io("VBUS_IN", Power)
 VBUS_OUT = io("VBUS_OUT", Power)
-PWR_EN = io("PWR_EN", Power)
+PWR_EN = io("PWR_EN", Net)
 GND = io("GND", Ground)
 
 # Internal nets

--- a/Interface_USB/FT232RL.zen
+++ b/Interface_USB/FT232RL.zen
@@ -16,7 +16,6 @@ Datasheet: https://ftdichip.com/wp-content/uploads/2020/08/DS_FT232R.pdf
 """
 
 load("@stdlib/interfaces.zen", "Usb2", "Uart", "Usart", "Rs232", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -67,19 +66,10 @@ elif communication_mode == CommunicationMode("UART"):
     _DSR = Net("_DSR")
     _DCD = Net("_DCD")
     _RI = Net("_RI")
-else:
-    _TXD = Net("_TXD")
-    _RXD = Net("_RXD")
-    _RTS = Net("_RTS")
-    _CTS = Net("_CTS")
-    _DTR = Net("_DTR")
-    _DSR = Net("_DSR")
-    _DCD = Net("_DCD")
-    _RI = Net("_RI")
 
 NRESET = io("NRESET", Net) if power_config == PowerConfig("BusPowered") else Net("RESET")
 
-VUSB = io("VUSB", Power, checks=voltage_within("4V to 5.5V"))
+VUSB = io("VUSB", Power(voltage="4V to 5.5V"))
 VOUT_3V3 = Power("VOUT_3V3")
 GND = io("GND", Ground)
 

--- a/Interface_USB/FT232RL.zen
+++ b/Interface_USB/FT232RL.zen
@@ -37,15 +37,6 @@ communication_mode = config("communication_mode", CommunicationMode, default="UA
 
 usb = io("USB", Usb2)
 
-_TXD = Net("_TXD")
-_RXD = Net("_RXD")
-_RTS = Net("_RTS")
-_CTS = Net("_CTS")
-_DTR = Net("_DTR")
-_DSR = Net("_DSR")
-_DCD = Net("_DCD")
-_RI = Net("_RI")
-
 if communication_mode == CommunicationMode("RS232"):
     rs232 = io("rs232", Rs232)
     _TXD = rs232.TX
@@ -56,34 +47,50 @@ if communication_mode == CommunicationMode("RS232"):
     _DSR = rs232.DSR
     _DCD = rs232.DCD
     _RI = rs232.RI
-
 elif communication_mode == CommunicationMode("USART"):
     usart = io("usart", Usart)
     _TXD = usart.TX
     _RXD = usart.RX
     _RTS = usart.RTS
     _CTS = usart.CTS
-
+    _DTR = Net("_DTR")
+    _DSR = Net("_DSR")
+    _DCD = Net("_DCD")
+    _RI = Net("_RI")
 elif communication_mode == CommunicationMode("UART"):
     uart = io("uart", Uart)
     _TXD = uart.TX
     _RXD = uart.RX
+    _RTS = Net("_RTS")
+    _CTS = Net("_CTS")
+    _DTR = Net("_DTR")
+    _DSR = Net("_DSR")
+    _DCD = Net("_DCD")
+    _RI = Net("_RI")
+else:
+    _TXD = Net("_TXD")
+    _RXD = Net("_RXD")
+    _RTS = Net("_RTS")
+    _CTS = Net("_CTS")
+    _DTR = Net("_DTR")
+    _DSR = Net("_DSR")
+    _DCD = Net("_DCD")
+    _RI = Net("_RI")
 
 NRESET = io("NRESET", Net) if power_config == PowerConfig("BusPowered") else Net("RESET")
 
 VUSB = io("VUSB", Power, checks=voltage_within("4V to 5.5V"))
-VOUT_3V3 = Net("VOUT_3V3")
+VOUT_3V3 = Power("VOUT_3V3")
 GND = io("GND", Ground)
 
 # VCC configuration
 if power_config == PowerConfig("BusPowered"):
-    VCC = Net("VCC")
+    VCC = Power("VCC")
     FerriteBead(name="FB1", mpn="MI0805K400R-10", package="0805", P1=VUSB, P2=VCC)
 else:
     VCC = io("VCC", Power)
 
 # VCCIO configuration
-_VCCIO_SUPPLY = Net("_VCCIO_SUPPLY")
 if vccio_level == VccioLevel("VCC"):
     _VCCIO_SUPPLY = VCC
 elif vccio_level == VccioLevel("VOUT_3V3"):

--- a/LED/WS2812B.zen
+++ b/LED/WS2812B.zen
@@ -22,11 +22,10 @@ Datasheet: https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("4.5V to 5.5V"))
+VDD = io("VDD", Power(voltage="4.5V to 5.5V"))
 GND = io("GND", Ground)
 DIN = io("DIN", Net)
 DOUT = io("DOUT", Net)

--- a/MCU_Espressif/ESP32-C3.zen
+++ b/MCU_Espressif/ESP32-C3.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.espressif.com/documentation/esp32-c3_datasheet_en.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "I2c", "Uart", "Usb2", "Jtag", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Inductance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import TLV70033 module from validated parts
 TLV70033_SOT23_5 = Module("../Regulator_Linear/TLV70033_SOT23-5.zen")
@@ -93,7 +92,7 @@ if clock_source == ClockSource("Crystal"):
 add_low_speed_oscillator = config("add_low_speed_oscillator", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2V to 3.6V"))
+VDD = io("VDD", Power(voltage="2V to 3.6V"))
 GND = io("GND", Ground)
 
 # USB IO (if enabled)

--- a/MCU_Espressif/ESP32-C3.zen
+++ b/MCU_Espressif/ESP32-C3.zen
@@ -98,7 +98,7 @@ GND = io("GND", Ground)
 
 # USB IO (if enabled)
 if add_usb_circuit:
-    usb = io("USB", Usb2, default=Usb2("USB"))
+    usb = io("USB", Usb2)
     VUSB = io("VUSB", Power)
 
 # JTAG IO (if enabled)
@@ -109,8 +109,8 @@ if add_jtag_header:
 _VDD3P3 = Net("VDD3P3")  # Filtered 3.3V for ESP32-C3
 _VDD3P3_CPU = VDD  # CPU power directly from VDD
 _VDDA = Net("VDDA") if add_vdda_filtering else VDD
-_VDD3P3_RTC = Net("VDD3P3_RTC") if add_rtc_filtering else VDD
-_VDD_SPI = Net("VDD_SPI")
+_VDD3P3_RTC = Power("VDD3P3_RTC") if add_rtc_filtering else VDD
+_VDD_SPI = Power("VDD_SPI")
 _LNA_IN = Net("LNA_IN")  # Internal net for antenna connection
 
 # CHIP_EN (reset) - conditionally exposed based on reset configuration
@@ -164,11 +164,15 @@ if add_jtag_header:
     _MTDI = jtag.TDI
     _MTMS = jtag.TMS
 else:
-    # Internal nets
-    _MTCK = Net("MTCK")
-    _MTDO = Net("MTDO")
-    _MTDI = Net("MTDI")
-    _MTMS = Net("MTMS")
+    # Expose as regular IOs when no dedicated JTAG header is added.
+    MTCK = io("MTCK", Net)
+    MTDO = io("MTDO", Net)
+    MTDI = io("MTDI", Net)
+    MTMS = io("MTMS", Net)
+    _MTCK = MTCK
+    _MTDO = MTDO
+    _MTDI = MTDI
+    _MTMS = MTMS
 
 # SPI Flash pins - conditionally exposed based on flash configuration
 if add_spi_flash:
@@ -246,18 +250,7 @@ Component(
     },
 )
 
-# JTAG Pin Handling - Expose as IOs when no header
-if not add_jtag_header:
-    # Expose JTAG pins as regular IOs
-    MTCK = io("MTCK", Net)
-    MTDO = io("MTDO", Net)
-    MTDI = io("MTDI", Net)
-    MTMS = io("MTMS", Net)
-    # Connect exposed IOs to internal nets
-    _MTCK = MTCK
-    _MTDO = MTDO
-    _MTDI = MTDI
-    _MTMS = MTMS
+# JTAG Pin Handling - exposed in the else branch above when no dedicated header.
 
 # Bulk Capacitors
 if add_bulk_caps:
@@ -523,8 +516,7 @@ if add_spi_flash:
 if add_antenna:
     # Internal nets for antenna connection
     _ANT_PORT1 = _LNA_IN  # Port 1 - near the chip
-    _ANT_MATCH = Net("ANT_MATCH")  # Junction between L1 and capacitors
-    _ANT_PORT2 = Net("ANT_PORT2")  # Port 2 - near the antenna
+    _ANT_MATCH = Net("ANT_MATCH")  # Junction between L1 and C2 (port 2 of the π-match)
     _ANT_FEED = Net("ANT_FEED")  # Connection to antenna after series resistor
 
     # Pi-network matching circuit
@@ -537,11 +529,8 @@ if add_antenna:
     # Port 2 side - Shunt capacitor C2
     Capacitor(name="C_ANT_PORT2", value=antenna_c2_value, package="0402", P1=_ANT_MATCH, P2=GND)
 
-    # Connection from matching network to antenna
-    _ANT_PORT2 = _ANT_MATCH
-
     # Series resistor to antenna (0ohms default for tuning/debugging)
-    Resistor(name="R_ANT", value=antenna_series_resistor_value, package="0402", P1=_ANT_PORT2, P2=_ANT_FEED)
+    Resistor(name="R_ANT", value=antenna_series_resistor_value, package="0402", P1=_ANT_MATCH, P2=_ANT_FEED)
 
     # Antenna component (2-pin chip antenna)
     Component(

--- a/MCU_Espressif/ESP32-S3.zen
+++ b/MCU_Espressif/ESP32-S3.zen
@@ -98,7 +98,7 @@ GND = io("GND", Ground)
 
 # USB IO (if enabled)
 if add_usb_circuit:
-    usb = io("USB", Usb2, default=Usb2("USB"))
+    usb = io("USB", Usb2)
     VUSB = io("VUSB", Power, checks=voltage_within("4V to 5.5V"))
 
 # JTAG IO (if enabled)
@@ -108,10 +108,10 @@ if add_jtag_header:
 # Internal nets
 _VDD3V3 = Net("VDD3V3")  # Filtered 3.3V for ESP32
 _VDD3P3 = _VDD3V3  # Connect VDD3P3 pins to filtered VDD3V3
-_VDDA = Net("VDDA") if add_vdda_filtering else VDD
-_VDD3P3_RTC = Net("VDD3P3_RTC") if add_rtc_filtering else VDD
+_VDDA = Power("VDDA") if add_vdda_filtering else VDD
+_VDD3P3_RTC = Power("VDD3P3_RTC") if add_rtc_filtering else VDD
 _VDD3P3_CPU = VDD  # Always connect VDD3P3_CPU directly to VDD
-_VDD_SPI = Net("VDD_SPI")
+_VDD_SPI = Power("VDD_SPI")
 _LNA_IN = Net("LNA_IN")  # Internal net for antenna connection
 
 # CHIP_PU (reset) - conditionally exposed based on reset configuration
@@ -151,11 +151,21 @@ _GPIO3 = Net("GPIO3")
 _GPIO45 = Net("GPIO45")
 _GPIO46 = Net("GPIO46")
 
-# JTAG pins - internal nets
-_MTCK = Net("MTCK")
-_MTDO = Net("MTDO")
-_MTDI = Net("MTDI")
-_MTMS = Net("MTMS")
+# JTAG pins - routed through a header, dedicated IOs, or left as internal nets.
+if add_jtag_header:
+    _MTCK = jtag.TCK
+    _MTDO = jtag.TDO
+    _MTDI = jtag.TDI
+    _MTMS = jtag.TMS
+else:
+    MTCK = io("MTCK", Net)
+    MTDO = io("MTDO", Net)
+    MTDI = io("MTDI", Net)
+    MTMS = io("MTMS", Net)
+    _MTCK = MTCK
+    _MTDO = MTDO
+    _MTDI = MTDI
+    _MTMS = MTMS
 
 # SPI Flash pins - conditionally exposed based on flash configuration
 if add_spi_flash:
@@ -248,23 +258,7 @@ Component(
     },
 )
 
-# JTAG Pin Handling
-if add_jtag_header:
-    # Connect internal JTAG nets to JTAG interface
-    _MTCK = jtag.TCK
-    _MTDO = jtag.TDO
-    _MTDI = jtag.TDI
-    _MTMS = jtag.TMS
-else:
-    # Expose JTAG pins as regular IOs
-    MTCK = io("MTCK", Net)
-    MTDO = io("MTDO", Net)
-    MTDI = io("MTDI", Net)
-    MTMS = io("MTMS", Net)
-    _MTCK = MTCK
-    _MTDO = MTDO
-    _MTDI = MTDI
-    _MTMS = MTMS
+# JTAG Pin Handling - resolved above alongside internal JTAG nets.
 
 # Bulk Capacitors
 if add_bulk_caps:
@@ -546,8 +540,7 @@ if add_spi_flash:
 if add_antenna:
     # Internal nets for antenna connection
     _ANT_PORT1 = _LNA_IN  # Port 1 - near the chip
-    _ANT_MATCH = Net("ANT_MATCH")  # Junction between L2 and capacitors
-    _ANT_PORT2 = Net("ANT_PORT2")  # Port 2 - near the antenna
+    _ANT_MATCH = Net("ANT_MATCH")  # Junction between L2 and C12 (port 2 of the π-match)
     _ANT_FEED = Net("ANT_FEED")  # Connection to antenna after series resistor
 
     # Pi-network matching circuit
@@ -560,11 +553,8 @@ if add_antenna:
     # Port 2 side - Shunt capacitor C12 (1.8-1.2pF recommended)
     Capacitor(name="C_ANT_PORT2", value=antenna_c12_value, package="0402", P1=_ANT_MATCH, P2=GND)
 
-    # Connection from matching network to antenna
-    _ANT_PORT2 = _ANT_MATCH
-
     # Series resistor to antenna (0ohms default for tuning/debugging)
-    Resistor(name="R_ANT", value=antenna_series_resistor_value, package="0402", P1=_ANT_PORT2, P2=_ANT_FEED)
+    Resistor(name="R_ANT", value=antenna_series_resistor_value, package="0402", P1=_ANT_MATCH, P2=_ANT_FEED)
 
     # Antenna component (2-pin chip antenna)
     # Pin 1: Feed, Pin 2: GND

--- a/MCU_Espressif/ESP32-S3.zen
+++ b/MCU_Espressif/ESP32-S3.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.espressif.com/documentation/esp32-s3_datasheet_en.pdf
 
 load("@stdlib/interfaces.zen", "Spi", "I2c", "Uart", "Usb2", "Jtag", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Inductance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import TLV70033 module from validated parts
 TLV70033_SOT23_5 = Module("../Regulator_Linear/TLV70033_SOT23-5.zen")
@@ -99,7 +98,7 @@ GND = io("GND", Ground)
 # USB IO (if enabled)
 if add_usb_circuit:
     usb = io("USB", Usb2)
-    VUSB = io("VUSB", Power, checks=voltage_within("4V to 5.5V"))
+    VUSB = io("VUSB", Power(voltage="4V to 5.5V"))
 
 # JTAG IO (if enabled)
 if add_jtag_header:

--- a/MCU_Microchip_ATmega/ATmega328-A.zen
+++ b/MCU_Microchip_ATmega/ATmega328-A.zen
@@ -54,77 +54,67 @@ passives_size = config("passives_size", PassivesSize, default="0402")
 # External IO
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-RESET = io("RESET", Net, default=Net("RESET"))
+RESET = io("RESET", Net)
 
 # Port B IO
-PB0 = io("PB0", Net, default=Net("PB0"))
-PB1 = io("PB1", Net, default=Net("PB1"))
-PB2 = io("PB2", Net, default=Net("PB2"))
-PB3 = io("PB3", Net, default=Net("PB3"))
-PB4 = io("PB4", Net, default=Net("PB4"))
-PB5 = io("PB5", Net, default=Net("PB5"))
-PB6 = io("PB6", Net, default=Net("PB6"))
-PB7 = io("PB7", Net, default=Net("PB7"))
+PB0 = io("PB0", Net)
+PB1 = io("PB1", Net)
 
 # Port C IO
-PC0 = io("PC0", Net, default=Net("PC0"))
-PC1 = io("PC1", Net, default=Net("PC1"))
-PC2 = io("PC2", Net, default=Net("PC2"))
-PC3 = io("PC3", Net, default=Net("PC3"))
-PC4 = io("PC4", Net, default=Net("PC4"))
-PC5 = io("PC5", Net, default=Net("PC5"))
+PC0 = io("PC0", Net)
+PC1 = io("PC1", Net)
+PC2 = io("PC2", Net)
+PC3 = io("PC3", Net)
 
 # Port D IO
-PD0 = io("PD0", Net, default=Net("PD0"))
-PD1 = io("PD1", Net, default=Net("PD1"))
-PD2 = io("PD2", Net, default=Net("PD2"))
-PD3 = io("PD3", Net, default=Net("PD3"))
-PD4 = io("PD4", Net, default=Net("PD4"))
-PD5 = io("PD5", Net, default=Net("PD5"))
-PD6 = io("PD6", Net, default=Net("PD6"))
-PD7 = io("PD7", Net, default=Net("PD7"))
+PD2 = io("PD2", Net)
+PD3 = io("PD3", Net)
+PD4 = io("PD4", Net)
+PD5 = io("PD5", Net)
+PD6 = io("PD6", Net)
+PD7 = io("PD7", Net)
 
 # Analog IO
-ADC6 = io("ADC6", Net, default=Net("ADC6"))
-ADC7 = io("ADC7", Net, default=Net("ADC7"))
+ADC6 = io("ADC6", Net)
+ADC7 = io("ADC7", Net)
 
 # Internal nets
 _AVCC = VCC
 _AREF = Net("AREF")
-_XTAL1 = Net("XTAL1") if clock_source == ClockSource("Crystal") else PB6
-_XTAL2 = Net("XTAL2") if clock_source == ClockSource("Crystal") else PB7
+_XTAL1 = Net("XTAL1") if clock_source == ClockSource("Crystal") else io("PB6", Net)
+_XTAL2 = Net("XTAL2") if clock_source == ClockSource("Crystal") else io("PB7", Net)
 
 # ---- Peripheral Interfaces -------------------------------------------------
 # SPI on PB3 (MOSI), PB4 (MISO), PB5 (SCK) + PB2 (CS) if enabled
 if enable_spi:
-    spi = io("SPI", Spi, default=Spi("SPI"))
+    spi = io("SPI", Spi)
     PB3_net = spi.MOSI
     PB4_net = spi.MISO
     PB5_net = spi.CLK  # SCK
     PB2_net = spi.CS
 else:
-    PB3_net = PB3
-    PB4_net = PB4
-    PB5_net = PB5
-    PB2_net = PB2
+    PB2_net = io("PB2", Net)
+    PB3_net = io("PB3", Net)
+    PB4_net = io("PB4", Net)
+    PB5_net = io("PB5", Net)
 
 # I2C on PC4 (SDA) / PC5 (SCL)
 if enable_i2c:
-    i2c = io("I2C", I2c, default=I2c("I2C"))
+    i2c = io("I2C", I2c)
     PC4_net = i2c.SDA
     PC5_net = i2c.SCL
 else:
-    PC4_net = PC4
-    PC5_net = PC5
+    PC4_net = io("PC4", Net)
+    PC5_net = io("PC5", Net)
 
 # UART on PD0 (RX) / PD1 (TX)
 if enable_uart or enable_ftdi_header:
-    uart = io("UART", Uart, default=Uart("UART"))
+    uart = io("UART", Uart)
     PD0_net = uart.RX
     PD1_net = uart.TX
 else:
-    PD0_net = PD0
-    PD1_net = PD1
+    PD0_net = io("PD0", Net)
+    PD1_net = io("PD1", Net)
 
 # FTDI Header (1x6)
 if enable_ftdi_header:

--- a/MCU_Microchip_ATtiny/ATtiny85-20S.zen
+++ b/MCU_Microchip_ATtiny/ATtiny85-20S.zen
@@ -265,8 +265,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VCC
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VUSB),
-            VOUT=Power(NET=VCC),
+            VIN=Power(VUSB),
+            VOUT=Power(VCC),
             GND=GND,
             add_input_cap=True,
             add_output_cap=True,

--- a/MCU_Microchip_ATtiny/ATtiny85-20S.zen
+++ b/MCU_Microchip_ATtiny/ATtiny85-20S.zen
@@ -19,7 +19,6 @@ Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2586-AVR-8-bit
 """
 
 load("@stdlib/interfaces.zen", "Spi", "I2c", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -62,7 +61,7 @@ GND = io("GND", Ground)
 
 # USB IO (if enabled)
 if add_usb:
-    VUSB = io("VUSB", Power, checks=voltage_within("4V to 5.5V"))
+    VUSB = io("VUSB", Power(voltage="4V to 5.5V"))
 
 # GPIO pins - conditionally exposed based on configuration
 # PB0 - AREF/MOSI/SDA

--- a/MCU_Microchip_SAMD/ATSAMD21E15A.zen
+++ b/MCU_Microchip_SAMD/ATSAMD21E15A.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.microchip.com/en-us/product/ATSAMD21E15
 
 load("@stdlib/interfaces.zen", "Swd", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -73,7 +72,7 @@ add_status_led = config("add_status_led", bool, default=True)
 add_spi_flash = config("add_spi_flash", bool, default=True, optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.62V to 3.63V"))
+VDD = io("VDD", Power(voltage="1.62V to 3.63V"))
 GND = io("GND", Ground)
 
 # USB IO (if enabled)

--- a/MCU_Microchip_SAMD/ATSAMD21E15A.zen
+++ b/MCU_Microchip_SAMD/ATSAMD21E15A.zen
@@ -138,8 +138,8 @@ else:
     PA31 = swd.SWDIO
 
 # Internal nets
-_VDDCORE = Net("VDDCORE")
-_VDDANA = Net("VDDANA") if add_analog_filtering else VDD
+_VDDCORE = Power("VDDCORE")
+_VDDANA = Power("VDDANA") if add_analog_filtering else VDD
 _RESET = Net("RESET")
 
 # Crystal oscillator nets
@@ -351,8 +351,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VDD
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VUSB),
-            VOUT=Power(NET=VDD),
+            VIN=Power(VUSB),
+            VOUT=Power(VDD),
             GND=GND,
             add_input_cap=add_decoupling,
             add_output_cap=add_decoupling,

--- a/MCU_Microchip_SAMD/ATSAMD21E18A.zen
+++ b/MCU_Microchip_SAMD/ATSAMD21E18A.zen
@@ -138,8 +138,8 @@ else:
     PA31 = swd.SWDIO
 
 # Internal nets
-_VDDCORE = Net("VDDCORE")
-_VDDANA = Net("VDDANA") if add_analog_filtering else VDD
+_VDDCORE = Power("VDDCORE")
+_VDDANA = Power("VDDANA") if add_analog_filtering else VDD
 _RESET = Net("RESET")
 
 # Crystal oscillator nets
@@ -351,8 +351,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VDD
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VUSB),
-            VOUT=Power(NET=VDD),
+            VIN=Power(VUSB),
+            VOUT=Power(VDD),
             GND=GND,
             add_input_cap=add_decoupling,
             add_output_cap=add_decoupling,

--- a/MCU_Microchip_SAMD/ATSAMD21E18A.zen
+++ b/MCU_Microchip_SAMD/ATSAMD21E18A.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.microchip.com/en-us/product/ATSAMD21E18
 
 load("@stdlib/interfaces.zen", "Swd", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -73,7 +72,7 @@ add_status_led = config("add_status_led", bool, default=True)
 add_spi_flash = config("add_spi_flash", bool, default=True, optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.62V to 3.63V"))
+VDD = io("VDD", Power(voltage="1.62V to 3.63V"))
 GND = io("GND", Ground)
 
 # USB IO (if enabled)

--- a/MCU_Nordic/nRF52840.zen
+++ b/MCU_Nordic/nRF52840.zen
@@ -73,7 +73,7 @@ GND = io("GND", Ground)
 # USB IO (if enabled)
 if add_usb:
     usb = io("USB", Usb2)
-    VUSB = io("VUSB", Net)
+    VUSB = io("VUSB", Power)
 
 # SWD IO (if enabled)
 if add_swd_header:
@@ -115,8 +115,8 @@ else:
     _RESET = Net("P0_18_RESET")
 
 # DCDC pins (always using DCDC mode)
-_DCC = Net("DCC")
-_DCCH = Net("DCCH")
+_DCC = Power("DCC")
+_DCCH = Power("DCCH")
 
 # Antenna net
 if add_antenna:
@@ -320,8 +320,7 @@ Inductor(name="L_DCDC", value="10uH", package="1210", P1=_DCC, P2=_L_DCDC_INT)
 Inductor(name="L_DEC4", value="15nH", package="0402", P1=_L_DCDC_INT, P2=_DEC4)
 
 
-# VSS_PA connection
-_VSS_PA = GND
+# VSS_PA redundantly re-tied to GND is handled up top already.
 
 # Additional VDD decoupling
 if add_decoupling_caps:
@@ -425,8 +424,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VDD
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VUSB),
-            VOUT=Power(NET=VDD),
+            VIN=Power(VUSB),
+            VOUT=Power(VDD),
             GND=GND,
             add_input_cap=True,
             add_output_cap=True,
@@ -452,8 +451,7 @@ if add_swd_header:
 if add_antenna:
     # Internal nets for antenna connection
     _ANT_PORT1 = _ANT  # Port 1 - near the chip
-    _ANT_MATCH = Net("ANT_MATCH")  # Junction between L2 and capacitors
-    _ANT_PORT2 = Net("ANT_PORT2")  # Port 2 - near the antenna
+    _ANT_MATCH = Net("ANT_MATCH")  # Junction between L2 and C12 (port 2 of the π-match)
     _ANT_FEED = Net("ANT_FEED")  # Connection to antenna after series resistor
 
     # Pi-network matching circuit
@@ -466,11 +464,8 @@ if add_antenna:
     # Port 2 side - Shunt capacitor C12
     Capacitor(name="C_ANT_PORT2", value=antenna_c12_value, package="0402", P1=_ANT_MATCH, P2=GND)
 
-    # Connection from matching network to antenna
-    _ANT_PORT2 = _ANT_MATCH
-
     # Series resistor to antenna (0ohms default for tuning/debugging)
-    Resistor(name="R_ANT", value=antenna_series_resistor_value, package="0402", P1=_ANT_PORT2, P2=_ANT_FEED)
+    Resistor(name="R_ANT", value=antenna_series_resistor_value, package="0402", P1=_ANT_MATCH, P2=_ANT_FEED)
 
     # Antenna component (2-pin chip antenna)
     # FEED: Antenna feed, PCB_Trace: Ground connection

--- a/MCU_Nordic/nRF52840.zen
+++ b/MCU_Nordic/nRF52840.zen
@@ -14,7 +14,6 @@ Datasheet: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/nrf52840_ps.html
 
 load("@stdlib/interfaces.zen", "Swd", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Inductance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Import modules
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -67,7 +66,7 @@ if add_antenna:
     antenna_series_resistor_value = config("antenna_series_resistor_value", Resistance, default="0ohms", optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="1.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # USB IO (if enabled)

--- a/MCU_RaspberryPi/RP2040.zen
+++ b/MCU_RaspberryPi/RP2040.zen
@@ -58,7 +58,7 @@ if specify_vdd_configuration:
     USB_VDD = io("USB_VDD", Net)
     ADC_AVDD = io("ADC_AVDD", Net)
 
-VDD_1V1 = io("VDD_1V1", Net)
+VDD_1V1 = io("VDD_1V1", Power)
 VDD_3V3 = io("VDD_3V3", Power)
 GND = io("GND", Ground)
 
@@ -67,7 +67,6 @@ usb = io("usb", Usb2)
 swd = io("swd", Swd)
 oscpair = OscPair("oscpair") if add_crystal else io("oscpair", OscPair)
 RUN = io("RUN", Net)
-TESTEN = io("TESTEN", Net)
 
 if add_usb_series_resistors:
     _usb = Usb2("RP_USB")

--- a/MCU_ST_STM32F0/STM32F072CBT.zen
+++ b/MCU_ST_STM32F0/STM32F072CBT.zen
@@ -86,7 +86,7 @@ GND = io("GND", Ground)
 # Optional VDDIO2 supply for specific I/Os
 add_vddio2 = config("add_vddio2", bool, default=False, optional=True)
 if add_vddio2:
-    VDDIO2 = io("VDDIO2", Net, default=Net("VDDIO2"))
+    VDDIO2 = io("VDDIO2", Power)
 
 # GPIO IO - Expose all available GPIO pins to the user
 # Port A pins
@@ -203,9 +203,13 @@ else:
     _BOOT0 = Net("BOOT0")  # Internal net for boot circuit
 
 # Internal nets
-_VDDA = Net("VDDA") if add_analog_decoupling else VDD
-_VSSA = io("_VSSA", Ground)
-_VBAT = Net("VBAT") if add_vbat_ferrite_bead else VDD
+if add_analog_decoupling:
+    _VDDA = Power("VDDA")
+    _VSSA = io("_VSSA", Ground)
+else:
+    _VDDA = VDD
+    _VSSA = GND
+_VBAT = Power("VBAT") if add_vbat_ferrite_bead else VDD
 
 # STMicroelectronics Arm Cortex-M0 MCU, 128KB flash, 16KB RAM, 48 MHz, 2.0-3.6V, 37 GPIO, LQFP48
 Component(
@@ -280,10 +284,6 @@ if add_analog_decoupling:
     NetTie(name="NT_VSSA", P1=GND, P2=_VSSA)
     Capacitor(name="C_VDDA", value="100nF", package="0402", P1=_VDDA, P2=_VSSA)
     Capacitor(name="C_VDDA2", value="1uF", package="0402", P1=_VDDA, P2=_VSSA)
-else:
-    # If analog decoupling is disabled, directly connect
-    _VDDA = VDD
-    _VSSA = GND
 
 # VDDIO2 decoupling (if used)
 if add_vddio2:
@@ -295,9 +295,6 @@ if add_vbat_ferrite_bead:
     FerriteBead(name="FB_VBAT", package="0402", P1=VDD, P2=_VBAT)
     # VBAT filtering capacitor
     Capacitor(name="C_VBAT", value="100nF", package="0402", P1=_VBAT, P2=GND)
-else:
-    # Direct connection to VDD
-    _VBAT = VDD
 
 # Reset Configuration
 if reset_configuration == ResetConfiguration("Pullup"):
@@ -502,8 +499,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VDD
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VUSB),
-            VOUT=Power(NET=VDD),
+            VIN=Power(VUSB),
+            VOUT=Power(VDD),
             GND=GND,
             add_input_cap=True,
             add_output_cap=True,
@@ -566,8 +563,8 @@ if add_can:
     _CAN_S = Net("CAN_S")
 
     # Create CAN bus nets since CanTtl only provides TX/RX
-    CAN_H = io("CAN_H", Net, default=Net("CAN_H"))
-    CAN_L = io("CAN_L", Net, default=Net("CAN_L"))
+    CAN_H = io("CAN_H", Net)
+    CAN_L = io("CAN_L", Net)
 
     # STM32F072CBT uses PB8 (CAN_RX) and PB9 (CAN_TX)
     Component(

--- a/MCU_ST_STM32F0/STM32F072CBT.zen
+++ b/MCU_ST_STM32F0/STM32F072CBT.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/stm32f072cb.pdf
 
 load("@stdlib/interfaces.zen", "Swd", "I2c", "Spi", "Uart", "CanTtl", "Usb2", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 AP2112K_3_3 = Module("../Regulator_Linear/AP2112K-3.3.zen")
 
 # Dependencies
@@ -80,7 +79,7 @@ if add_can:
     add_can_termination = config("add_can_termination", bool, default=True, optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2V to 3.6V"))
+VDD = io("VDD", Power(voltage="2V to 3.6V"))
 GND = io("GND", Ground)
 
 # Optional VDDIO2 supply for specific I/Os

--- a/MCU_ST_STM32F1/STM32F103C8T.zen
+++ b/MCU_ST_STM32F1/STM32F103C8T.zen
@@ -128,7 +128,7 @@ else:
 # USB IO (if enabled) - PA11 and PA12
 if add_usb:
     usb = io("USB", Usb2)
-    VUSB = io("VUSB", Net)
+    VUSB = io("VUSB", Power)
     PA11 = usb.D.N
     PA12 = usb.D.P
 else:

--- a/MCU_ST_STM32F1/STM32F103C8T.zen
+++ b/MCU_ST_STM32F1/STM32F103C8T.zen
@@ -12,7 +12,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/stm32f103c8.pdf
 
 load("@stdlib/interfaces.zen", "Swd", "I2c", "Spi", "Uart", "Can", "Usb2", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -75,7 +74,7 @@ if add_usb:
     power_from_usb = config("power_from_usb", bool, default=True, optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2V to 3.6V"))
+VDD = io("VDD", Power(voltage="2V to 3.6V"))
 GND = io("GND", Ground)
 
 # GPIO IO - Expose all available GPIO pins to the user

--- a/MCU_ST_STM32F1/STM32F103C8T.zen
+++ b/MCU_ST_STM32F1/STM32F103C8T.zen
@@ -172,9 +172,13 @@ else:
     _NRST = Net("NRST")  # Internal net for reset circuit
 
 # Internal nets
-_VDDA = io("_VDDA", Power)
-_VSSA = io("_VSSA", Ground)
-_VBAT = Net("VBAT")
+if add_analog_decoupling:
+    _VDDA = io("_VDDA", Power)
+    _VSSA = io("_VSSA", Ground)
+else:
+    _VDDA = VDD
+    _VSSA = GND
+_VBAT = Power("VBAT") if add_vbatt_ferrite_bead else VDD
 _BOOT0 = Net("BOOT0")
 
 # STMicroelectronics Arm Cortex-M3 MCU, 64KB flash, 20KB RAM, 72 MHz, 2.0-3.6V, 37 GPIO, LQFP48
@@ -248,20 +252,12 @@ if add_analog_decoupling:
     Capacitor(name="C_VDDA", value="100nF", package="0402", P1=_VDDA, P2=_VSSA)
     Capacitor(name="C_VDDA2", value="1uF", package="0402", P1=_VDDA, P2=_VSSA)
 
-else:
-    # If analog decoupling is disabled, always tie directly
-    _VDDA = VDD
-    _VSSA = GND
-
 # VBAT Connection
 if add_vbatt_ferrite_bead:
     # Connect to VDD through ferrite bead for noise filtering
     FerriteBead(name="FB_VBAT", package="0402", P1=VDD, P2=_VBAT)
     # VBAT filtering capacitor
     Capacitor(name="C_VBAT", value="100nF", package="0402", P1=_VBAT, P2=GND)
-else:
-    # Direct connection to VDD
-    _VBAT = VDD
 
 
 # Reset Configuration

--- a/MCU_ST_STM32F4/STM32F405RGT.zen
+++ b/MCU_ST_STM32F4/STM32F405RGT.zen
@@ -27,7 +27,6 @@ load(
     "Ground",
     "NotConnected",
 )
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -90,7 +89,7 @@ GND = io("GND", Ground)
 
 # USB IO (if enabled)
 if add_usb:
-    VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+    VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
     usb = io("USB", Usb2)
     USB_DM = usb.D.N
     USB_DP = usb.D.P

--- a/MCU_ST_STM32F4/STM32F405RGT.zen
+++ b/MCU_ST_STM32F4/STM32F405RGT.zen
@@ -91,13 +91,13 @@ GND = io("GND", Ground)
 # USB IO (if enabled)
 if add_usb:
     VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
-    usb = io("USB", Usb2, default=Usb2("USB"))
+    usb = io("USB", Usb2)
     USB_DM = usb.D.N
     USB_DP = usb.D.P
 
 # SWD IO (if enabled)
 if add_swd_header:
-    swd = io("SWD", Swd, default=Swd("SWD"))
+    swd = io("SWD", Swd)
     PA13 = swd.SWDIO
     PA14 = swd.SWCLK
 else:
@@ -105,10 +105,10 @@ else:
     PA14 = Net("PA14")
 
 # Internal nets
-_VDDA = Net("VDDA") if add_vdda_filter else VDD
-_VBAT = Net("VBAT") if add_vbat_battery else VDD
-_VCAP1 = Net("VCAP_1")
-_VCAP2 = Net("VCAP_2")
+_VDDA = Power("VDDA") if add_vdda_filter else VDD
+_VBAT = Power("VBAT") if add_vbat_battery else VDD
+_VCAP1 = Power("VCAP_1")
+_VCAP2 = Power("VCAP_2")
 _NRST = Net("NRST")
 _BOOT0 = Net("BOOT0")
 _BOOT1 = Net("BOOT1")

--- a/MCU_ST_STM32F4/STM32F411CEU.zen
+++ b/MCU_ST_STM32F4/STM32F411CEU.zen
@@ -191,10 +191,14 @@ else:
     _BOOT0 = Net("BOOT0")  # Internal net for boot circuit
 
 # Internal nets
-_VDDA = Net("VDDA") if add_analog_decoupling else VDD
-_VSSA = io("_VSSA", Ground)
-_VBAT = Net("VBAT") if add_vbat_ferrite_bead else VDD
-_VCAP1 = Net("VCAP1")
+if add_analog_decoupling:
+    _VDDA = Power("VDDA")
+    _VSSA = io("_VSSA", Ground)
+else:
+    _VDDA = VDD
+    _VSSA = GND
+_VBAT = Power("VBAT") if add_vbat_ferrite_bead else VDD
+_VCAP1 = Power("VCAP1")
 
 # STMicroelectronics Arm Cortex-M4 MCU, 512KB flash, 128KB RAM, 100 MHz, 1.7-3.6V, 36 GPIO, UFQFPN48
 Component(
@@ -273,10 +277,6 @@ if add_analog_decoupling:
     NetTie(name="NT_VSSA", P1=GND, P2=_VSSA)
     Capacitor(name="C_VDDA", value="100nF", package="0402", P1=_VDDA, P2=_VSSA)
     Capacitor(name="C_VDDA2", value="1uF", package="0402", P1=_VDDA, P2=_VSSA)
-else:
-    # If analog decoupling is disabled, always tie directly
-    _VDDA = VDD
-    _VSSA = GND
 
 # VBAT Connection
 if add_vbat_ferrite_bead:
@@ -284,9 +284,6 @@ if add_vbat_ferrite_bead:
     FerriteBead(name="FB_VBAT", package="0402", P1=VDD, P2=_VBAT)
     # VBAT filtering capacitor
     Capacitor(name="C_VBAT", value="100nF", package="0402", P1=_VBAT, P2=GND)
-else:
-    # Direct connection to VDD
-    _VBAT = VDD
 
 # Reset Configuration
 if reset_configuration == ResetConfiguration("Pullup"):

--- a/MCU_ST_STM32F4/STM32F411CEU.zen
+++ b/MCU_ST_STM32F4/STM32F411CEU.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/stm32f411ce.pdf
 
 load("@stdlib/interfaces.zen", "Swd", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 TLV70033_SOT23_5 = Module("../Regulator_Linear/TLV70033_SOT23-5.zen")
 
 # Dependencies
@@ -77,7 +76,7 @@ if add_usb:
 add_spi_flash = config("add_spi_flash", bool, default=True, optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.7V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.7V to 3.6V"))
 GND = io("GND", Ground)
 
 # GPIO IO - Expose all available GPIO pins to the user

--- a/MCU_ST_STM32F4/STM32F415RGT.zen
+++ b/MCU_ST_STM32F4/STM32F415RGT.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/stm32f415rg.pdf
 
 load("@stdlib/interfaces.zen", "Usb2", "Swd", "I2c", "I2s", "Spi", "Uart", "Can", "Sdio", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 AP2112K_3_3 = Module("../Regulator_Linear/AP2112K-3.3.zen")
 
 # Dependencies
@@ -164,7 +163,7 @@ PD2 = io("PD2", Net)
 # USB IO (if enabled) - PA11 and PA12
 if add_usb:
     usb = io("USB", Usb2)
-    VUSB = io("VUSB", Power, checks=voltage_within("4V to 5.5V"))
+    VUSB = io("VUSB", Power(voltage="4V to 5.5V"))
     PA11 = usb.D.N
     PA12 = usb.D.P
 else:

--- a/MCU_ST_STM32F4/STM32F415RGT.zen
+++ b/MCU_ST_STM32F4/STM32F415RGT.zen
@@ -215,11 +215,15 @@ else:
     _BOOT0 = Net("BOOT0")  # Internal net for boot circuit
 
 # Internal nets
-_VDDA = Net("VDDA") if add_analog_decoupling else VDD
-_VSSA = io("_VSSA", Ground)
-_VBAT = Net("VBAT") if add_vbat_ferrite_bead else VDD
-_VCAP1 = Net("VCAP1")
-_VCAP2 = Net("VCAP2")
+if add_analog_decoupling:
+    _VDDA = Power("VDDA")
+    _VSSA = io("_VSSA", Ground)
+else:
+    _VDDA = VDD
+    _VSSA = GND
+_VBAT = Power("VBAT") if add_vbat_ferrite_bead else VDD
+_VCAP1 = Power("VCAP1")
+_VCAP2 = Power("VCAP2")
 
 # STMicroelectronics Arm Cortex-M4 MCU, 1024 KB flash, 192 KB RAM, 168 MHz, crypto, 1.8-3.6 V, 51 GPIO, LQFP64
 Component(
@@ -314,10 +318,6 @@ if add_analog_decoupling:
     NetTie(name="NT_VSSA", P1=GND, P2=_VSSA)
     Capacitor(name="C_VDDA", value="100nF", package="0402", P1=_VDDA, P2=_VSSA)
     Capacitor(name="C_VDDA2", value="1uF", package="0402", P1=_VDDA, P2=_VSSA)
-else:
-    # If analog decoupling is disabled, always tie directly
-    _VDDA = VDD
-    _VSSA = GND
 
 # VBAT Connection
 if add_vbat_ferrite_bead:
@@ -325,9 +325,6 @@ if add_vbat_ferrite_bead:
     FerriteBead(name="FB_VBAT", package="0402", P1=VDD, P2=_VBAT)
     # VBAT filtering capacitor
     Capacitor(name="C_VBAT", value="100nF", package="0402", P1=_VBAT, P2=GND)
-else:
-    # Direct connection to VDD
-    _VBAT = VDD
 
 # Reset Configuration
 if reset_configuration == ResetConfiguration("Pullup"):
@@ -571,8 +568,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VDD
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VUSB),
-            VOUT=Power(NET=VDD),
+            VIN=Power(VUSB),
+            VOUT=Power(VDD),
             GND=GND,
             add_input_cap=add_power_decoupling,
             add_output_cap=add_power_decoupling,

--- a/MCU_ST_STM32G0/STM32G030F6P.zen
+++ b/MCU_ST_STM32G0/STM32G030F6P.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/stm32g030c6.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Uart", "Swd", "Usb2", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -49,7 +48,7 @@ add_gpio_headers = config("add_gpio_headers", bool, default=True, optional=True)
 
 # External IO
 GND = io("GND", Ground)
-VDD = io("VDD", Power, checks=voltage_within("2V to 3.6V"))
+VDD = io("VDD", Power(voltage="2V to 3.6V"))
 
 # SWD IO (if enabled)
 if add_swd_header:

--- a/MCU_ST_STM32G0/STM32G030F6P.zen
+++ b/MCU_ST_STM32G0/STM32G030F6P.zen
@@ -53,42 +53,39 @@ VDD = io("VDD", Power, checks=voltage_within("2V to 3.6V"))
 
 # SWD IO (if enabled)
 if add_swd_header:
-    swd = io("SWD", Swd, default=Swd("SWD"))
+    swd = io("SWD", Swd)
 
-# Reset and Boot pins
-NRST = io("NRST", Net, default=Net("NRST"))
-BOOT0 = io("BOOT0", Net, default=Net("BOOT0"))
+# Reset pin
+NRST = io("NRST", Net)
 
 # Port A pins
-PA0 = io("PA0", Net, default=Net("PA0"))
-PA1 = io("PA1", Net, default=Net("PA1"))
-PA2 = io("PA2", Net, default=Net("PA2"))
-PA3 = io("PA3", Net, default=Net("PA3"))
-PA4 = io("PA4", Net, default=Net("PA4"))
-PA5 = io("PA5", Net, default=Net("PA5"))
-PA6 = io("PA6", Net, default=Net("PA6"))
-PA7 = io("PA7", Net, default=Net("PA7"))
-PA8_PB0_PB1_PB2 = io("PA8_PB0_PB1_PB2", Net, default=Net("PA8/PB0/PB1/PB2"))
-PA9_PA11 = io("PA9_PA11", Net, default=Net("PA9/PA11"))
-PA10_PA12 = io("PA10_PA12", Net, default=Net("PA10/PA12"))
-PA13 = io("PA13", Net, default=Net("PA13"))
-PA14_PA15 = io("PA14_PA15", Net, default=Net("PA14/PA15"))
+PA0 = io("PA0", Net)
+PA1 = io("PA1", Net)
+PA2 = io("PA2", Net)
+PA3 = io("PA3", Net)
+PA4 = io("PA4", Net)
+PA5 = io("PA5", Net)
+PA6 = io("PA6", Net)
+PA7 = io("PA7", Net)
+PA8_PB0_PB1_PB2 = io("PA8_PB0_PB1_PB2", Net)
+PA9_PA11 = io("PA9_PA11", Net)
+PA10_PA12 = io("PA10_PA12", Net)
 
 # Port B pins
-PB3_PB4_PB5_PB6 = io("PB3_PB4_PB5_PB6", Net, default=Net("PB3/PB4/PB5/PB6"))
-PB7_PB8 = io("PB7_PB8", Net, default=Net("PB7/PB8"))
-PB9_PC14 = io("PB9_PC14", Net, default=Net("PB9/PC14"))
+PB3_PB4_PB5_PB6 = io("PB3_PB4_PB5_PB6", Net)
+PB7_PB8 = io("PB7_PB8", Net)
+PB9_PC14 = io("PB9_PC14", Net)
 
 # Port C pin
-PC15 = io("PC15", Net, default=Net("PC15"))
+PC15 = io("PC15", Net)
 
 # SWD interface routing
 if add_swd_header:
     PA13_net = swd.SWDIO
     PA14_net = swd.SWCLK
 else:
-    PA13_net = PA13
-    PA14_net = PA14_PA15
+    PA13_net = io("PA13", Net)
+    PA14_net = io("PA14_PA15", Net)
 
 # STMicroelectronics Arm Cortex-M0+ MCU, 32KB flash, 8KB RAM, 64 MHz, 2.0-3.6V, 17 GPIO, TSSOP20
 Component(

--- a/MCU_ST_STM32G4/STM32G431CBT.zen
+++ b/MCU_ST_STM32G4/STM32G431CBT.zen
@@ -174,9 +174,13 @@ else:
 PG10 = _NRST
 
 # Internal nets
-_VDDA = Net("VDDA") if add_analog_decoupling else VDD
-_VSSA = io("_VSSA", Ground)
-_VBAT = Net("VBAT") if add_vbat_ferrite_bead else VDD
+if add_analog_decoupling:
+    _VDDA = Power("VDDA")
+    _VSSA = io("_VSSA", Ground)
+else:
+    _VDDA = VDD
+    _VSSA = GND
+_VBAT = Power("VBAT") if add_vbat_ferrite_bead else VDD
 _VREF_PLUS = Net("VREF+") if add_vref_buffer else VDD
 
 # STMicroelectronics Arm Cortex-M4 MCU, 128KB flash, 32KB RAM, 170 MHz, 1.71-3.6V, 44 GPIO, LQFP48
@@ -251,15 +255,9 @@ if add_analog_decoupling:
     # VDDA decoupling
     Capacitor(name="C_VDDA", value="100nF", package=passives_size, P1=_VDDA, P2=_VSSA)
     Capacitor(name="C_VDDA2", value="1uF", package=passives_size, P1=_VDDA, P2=_VSSA)
-elif not add_analog_decoupling and add_power_decoupling:
-    # Direct connection to VDD
+elif add_power_decoupling:
+    # Direct connection to VDD (analog decoupling disabled)
     Capacitor(name="C_VDDA", value="100nF", package=passives_size, P1=VDD, P2=GND)
-    _VDDA = VDD
-    _VSSA = GND
-else:
-    # If analog decoupling is disabled, tie directly
-    _VDDA = VDD
-    _VSSA = GND
 
 # VBAT Connection
 if add_vbat_ferrite_bead:
@@ -267,13 +265,9 @@ if add_vbat_ferrite_bead:
     FerriteBead(name="FB_VBAT", package=passives_size, P1=VDD, P2=_VBAT)
     # VBAT filtering capacitor
     Capacitor(name="C_VBAT", value="100nF", package=passives_size, P1=_VBAT, P2=GND)
-elif not add_vbat_ferrite_bead and add_power_decoupling:
-    # Direct connection to VDD
+elif add_power_decoupling:
+    # Direct connection to VDD (VBAT ferrite bead disabled)
     Capacitor(name="C_VBAT", value="100nF", package=passives_size, P1=VDD, P2=GND)
-    _VBAT = VDD
-else:
-    # If analog decoupling is disabled, tie directly
-    _VBAT = VDD
 
 # Voltage Reference Buffer
 if add_vref_buffer:
@@ -492,8 +486,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VDD
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VUSB),
-            VOUT=Power(NET=VDD),
+            VIN=Power(VUSB),
+            VOUT=Power(VDD),
             GND=GND,
             # Use default configuration for the regulator
             add_input_cap=True,

--- a/MCU_ST_STM32G4/STM32G431CBT.zen
+++ b/MCU_ST_STM32G4/STM32G431CBT.zen
@@ -16,7 +16,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/stm32g431cb.pdf
 
 load("@stdlib/interfaces.zen", "Swd", "I2c", "Spi", "Uart", "Can", "Usb2", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 AP2112K_3_3 = Module("../Regulator_Linear/AP2112K-3.3.zen")
 
 # Dependencies
@@ -79,7 +78,7 @@ if add_usb:
 add_fdcan = config("add_fdcan", bool, default=True, optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.71V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.71V to 3.6V"))
 GND = io("GND", Ground)
 
 # GPIO IO - Expose all available GPIO pins to the user

--- a/Memory_Flash/W25Q128JVE.zen
+++ b/Memory_Flash/W25Q128JVE.zen
@@ -12,7 +12,6 @@ Datasheet: https://www.winbond.com/resource-files/w25q128jv%20revf%2003272018%20
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -34,7 +33,7 @@ if spi_mode == SpiMode("Standard") or spi_mode == SpiMode("Dual"):
 
 # External IO
 spi = io("spi", Spi)
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on SPI mode and configuration

--- a/Memory_Flash/W25Q128JVE.zen
+++ b/Memory_Flash/W25Q128JVE.zen
@@ -33,20 +33,20 @@ if spi_mode == SpiMode("Standard") or spi_mode == SpiMode("Dual"):
         reset_pullup = config("reset_pullup", bool, default=True)
 
 # External IO
-spi = io("spi", Spi, default=Spi("spi"))
+spi = io("spi", Spi)
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on SPI mode and configuration
 if spi_mode == SpiMode("Quad"):
-    IO2 = io("IO2", Net, default=Net("IO2"))
-    IO3 = io("IO3", Net, default=Net("IO3"))
+    IO2 = io("IO2", Net)
+    IO3 = io("IO3", Net)
     _WP = IO2
     _HOLD = IO3
 else:
     # In non-Quad modes, WP and HOLD can be control pins
     if write_protect_mode == WriteProtectMode("Hardware"):
-        WP_CTRL = io("WP", Net, default=Net("nWP"))
+        WP_CTRL = io("WP", Net)
         _WP = WP_CTRL
     elif write_protect_mode == WriteProtectMode("None"):
         _WP = VCC
@@ -54,7 +54,7 @@ else:
         _WP = Net("WP/IO2")
 
     if enable_hold:
-        HOLD_CTRL = io("HOLD", Net, default=Net("nHOLD"))
+        HOLD_CTRL = io("HOLD", Net)
         _HOLD = HOLD_CTRL
     else:
         _HOLD = Net("HOLD")
@@ -64,9 +64,7 @@ _CS = spi.CS
 _CLK = spi.CLK
 _DI_IO0 = spi.MOSI
 _DO_IO1 = spi.MISO
-_EP = Net("EP")  # Exposed pad
-# Connect exposed pad to GND
-_EP = GND
+# Exposed pad: tied to GND.
 
 
 # 128Mbit / 16MiB Serial Flash Memory, Standard/Dual/Quad SPI, 2.7-3.6V, WSON-8
@@ -83,7 +81,7 @@ Component(
         "~{HOLD}/~{RESET}/IO_{3}": _HOLD,
         "VCC": VCC,
         "GND": GND,
-        "EP": _EP,
+        "EP": GND,
     },
 )
 

--- a/Memory_Flash/W25Q128JVS.zen
+++ b/Memory_Flash/W25Q128JVS.zen
@@ -12,7 +12,6 @@ Datasheet: http://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -34,7 +33,7 @@ if spi_mode == SpiMode("Standard") or spi_mode == SpiMode("Dual"):
 
 # External IO
 spi = io("spi", Spi)
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on SPI mode and configuration

--- a/Memory_Flash/W25Q128JVS.zen
+++ b/Memory_Flash/W25Q128JVS.zen
@@ -33,20 +33,20 @@ if spi_mode == SpiMode("Standard") or spi_mode == SpiMode("Dual"):
         reset_pullup = config("reset_pullup", bool, default=True)
 
 # External IO
-spi = io("spi", Spi, default=Spi("spi"))
+spi = io("spi", Spi)
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on SPI mode and configuration
 if spi_mode == SpiMode("Quad"):
-    IO2 = io("IO2", Net, default=Net("IO2"))
-    IO3 = io("IO3", Net, default=Net("IO3"))
+    IO2 = io("IO2", Net)
+    IO3 = io("IO3", Net)
     _WP = IO2
     _HOLD = IO3
 else:
     # In non-Quad modes, WP and HOLD can be control pins
     if write_protect_mode == WriteProtectMode("Hardware"):
-        WP_CTRL = io("WP", Net, default=Net("nWP"))
+        WP_CTRL = io("WP", Net)
         _WP = WP_CTRL
     elif write_protect_mode == WriteProtectMode("None"):
         _WP = VCC
@@ -54,7 +54,7 @@ else:
         _WP = Net("WP/IO2")
 
     if enable_hold:
-        HOLD_CTRL = io("HOLD", Net, default=Net("nHOLD"))
+        HOLD_CTRL = io("HOLD", Net)
         _HOLD = HOLD_CTRL
     else:
         _HOLD = Net("HOLD")

--- a/Memory_Flash/W25Q32JVSS.zen
+++ b/Memory_Flash/W25Q32JVSS.zen
@@ -36,20 +36,20 @@ if spi_mode == SpiMode("Standard") or spi_mode == SpiMode("Dual"):
         reset_pullup = config("reset_pullup", bool, default=True)
 
 # External IO
-spi = io("spi", Spi, default=Spi("spi"))
+spi = io("spi", Spi)
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on SPI mode and configuration
 if spi_mode == SpiMode("Quad"):
-    IO2 = io("IO2", Net, default=Net("IO2"))
-    IO3 = io("IO3", Net, default=Net("IO3"))
+    IO2 = io("IO2", Net)
+    IO3 = io("IO3", Net)
     _WP = IO2
     _HOLD = IO3
 else:
     # In non-Quad modes, WP and HOLD can be control pins
     if write_protect_mode == WriteProtectMode("Hardware"):
-        WP_CTRL = io("WP", Net, default=Net("nWP"))
+        WP_CTRL = io("WP", Net)
         _WP = WP_CTRL
     elif write_protect_mode == WriteProtectMode("None"):
         _WP = VCC
@@ -57,7 +57,7 @@ else:
         _WP = Net("WP/IO2")
 
     if enable_hold:
-        HOLD_CTRL = io("HOLD", Net, default=Net("nHOLD"))
+        HOLD_CTRL = io("HOLD", Net)
         _HOLD = HOLD_CTRL
     else:
         _HOLD = Net("HOLD")

--- a/Memory_Flash/W25Q32JVSS.zen
+++ b/Memory_Flash/W25Q32JVSS.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.winbond.com/resource-files/w25q32jv%20revg%2003272018%20p
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -37,7 +36,7 @@ if spi_mode == SpiMode("Standard") or spi_mode == SpiMode("Dual"):
 
 # External IO
 spi = io("spi", Spi)
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on SPI mode and configuration

--- a/Memory_Flash/W25X20CLSN.zen
+++ b/Memory_Flash/W25X20CLSN.zen
@@ -15,7 +15,6 @@ Datasheet: http://www.winbond.com/resource-files/w25x20cl_f%2020140325.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -34,7 +33,7 @@ if not enable_hold:
 
 # External IO
 spi = io("spi", Spi)
-VCC = io("VCC", Power, checks=voltage_within("2.3V to 3.6V"))
+VCC = io("VCC", Power(voltage="2.3V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on configuration

--- a/Memory_Flash/W25X20CLSN.zen
+++ b/Memory_Flash/W25X20CLSN.zen
@@ -33,13 +33,13 @@ if not enable_hold:
     reset_pullup = config("reset_pullup", bool, default=True)
 
 # External IO
-spi = io("spi", Spi, default=Spi("spi"))
+spi = io("spi", Spi)
 VCC = io("VCC", Power, checks=voltage_within("2.3V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on configuration
 if write_protect_mode == WriteProtectMode("Hardware"):
-    WP_CTRL = io("WP", Net, default=Net("nWP"))
+    WP_CTRL = io("WP", Net)
     _WP = WP_CTRL
 elif write_protect_mode == WriteProtectMode("None"):
     _WP = VCC
@@ -47,7 +47,7 @@ else:  # Software mode
     _WP = Net("WP")
 
 if enable_hold:
-    HOLD_CTRL = io("HOLD", Net, default=Net("nHOLD"))
+    HOLD_CTRL = io("HOLD", Net)
     _HOLD = HOLD_CTRL
 else:
     _HOLD = Net("HOLD")

--- a/Memory_Flash/W25X40CLSN.zen
+++ b/Memory_Flash/W25X40CLSN.zen
@@ -15,7 +15,6 @@ Datasheet: http://www.advanced-monolithic.com/pdf/ds1117.pdf
 """
 
 load("@stdlib/interfaces.zen", "Spi", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -34,7 +33,7 @@ if not enable_hold:
 
 # External IO
 spi = io("spi", Spi)
-VCC = io("VCC", Power, checks=voltage_within("2.3V to 3.6V"))
+VCC = io("VCC", Power(voltage="2.3V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on configuration

--- a/Memory_Flash/W25X40CLSN.zen
+++ b/Memory_Flash/W25X40CLSN.zen
@@ -33,13 +33,13 @@ if not enable_hold:
     reset_pullup = config("reset_pullup", bool, default=True)
 
 # External IO
-spi = io("spi", Spi, default=Spi("spi"))
+spi = io("spi", Spi)
 VCC = io("VCC", Power, checks=voltage_within("2.3V to 3.6V"))
 GND = io("GND", Ground)
 
 # Additional IO based on configuration
 if write_protect_mode == WriteProtectMode("Hardware"):
-    WP_CTRL = io("WP", Net, default=Net("nWP"))
+    WP_CTRL = io("WP", Net)
     _WP = WP_CTRL
 elif write_protect_mode == WriteProtectMode("None"):
     _WP = VCC
@@ -47,7 +47,7 @@ else:  # Software mode
     _WP = Net("WP")
 
 if enable_hold:
-    HOLD_CTRL = io("HOLD", Net, default=Net("nHOLD"))
+    HOLD_CTRL = io("HOLD", Net)
     _HOLD = HOLD_CTRL
 else:
     _HOLD = Net("HOLD")

--- a/Oscillator/MAX7375AXR105.zen
+++ b/Oscillator/MAX7375AXR105.zen
@@ -57,7 +57,7 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-CLOCK_OUT = io("CLOCK_OUT", Net, default=Net("CLK_1MHZ"))
+CLOCK_OUT = io("CLOCK_OUT", Net)
 
 # Internal nets
 if add_series_termination:
@@ -67,7 +67,7 @@ else:
 
 # Power supply net (filtered or direct)
 if power_supply_config == PowerSupplyConfiguration("Noisy"):
-    _VCC_CHIP = Net("VCC_FILTERED")
+    _VCC_CHIP = Power("VCC_FILTERED")
 else:
     _VCC_CHIP = VCC
 

--- a/Oscillator/MAX7375AXR105.zen
+++ b/Oscillator/MAX7375AXR105.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ if add_series_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 CLOCK_OUT = io("CLOCK_OUT", Net)
 

--- a/Oscillator/MAX7375AXR185.zen
+++ b/Oscillator/MAX7375AXR185.zen
@@ -57,7 +57,7 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-CLOCK_OUT = io("CLOCK_OUT", Net, default=Net("CLK_1M8432"))
+CLOCK_OUT = io("CLOCK_OUT", Net)
 
 # Internal nets
 if add_series_termination:
@@ -67,7 +67,7 @@ else:
 
 # Power supply net (filtered or direct)
 if power_supply_config == PowerSupplyConfiguration("Noisy"):
-    _VCC_CHIP = Net("VCC_FILTERED")
+    _VCC_CHIP = Power("VCC_FILTERED")
 else:
     _VCC_CHIP = VCC
 

--- a/Oscillator/MAX7375AXR185.zen
+++ b/Oscillator/MAX7375AXR185.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ if add_series_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 CLOCK_OUT = io("CLOCK_OUT", Net)
 

--- a/Oscillator/MAX7375AXR365.zen
+++ b/Oscillator/MAX7375AXR365.zen
@@ -57,7 +57,7 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-CLOCK_OUT = io("CLOCK_OUT", Net, default=Net("CLK_3M6864"))
+CLOCK_OUT = io("CLOCK_OUT", Net)
 
 # Internal nets
 if add_series_termination:
@@ -67,7 +67,7 @@ else:
 
 # Power supply net (filtered or direct)
 if power_supply_config == PowerSupplyConfiguration("Noisy"):
-    _VCC_CHIP = Net("VCC_FILTERED")
+    _VCC_CHIP = Power("VCC_FILTERED")
 else:
     _VCC_CHIP = VCC
 

--- a/Oscillator/MAX7375AXR365.zen
+++ b/Oscillator/MAX7375AXR365.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ if add_series_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 CLOCK_OUT = io("CLOCK_OUT", Net)
 

--- a/Oscillator/MAX7375AXR375.zen
+++ b/Oscillator/MAX7375AXR375.zen
@@ -57,7 +57,7 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-CLOCK_OUT = io("CLOCK_OUT", Net, default=Net("CLK_3M69"))
+CLOCK_OUT = io("CLOCK_OUT", Net)
 
 # Internal nets
 if add_series_termination:
@@ -67,7 +67,7 @@ else:
 
 # Power supply net (filtered or direct)
 if power_supply_config == PowerSupplyConfiguration("Noisy"):
-    _VCC_CHIP = Net("VCC_FILTERED")
+    _VCC_CHIP = Power("VCC_FILTERED")
 else:
     _VCC_CHIP = VCC
 

--- a/Oscillator/MAX7375AXR375.zen
+++ b/Oscillator/MAX7375AXR375.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ if add_series_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 CLOCK_OUT = io("CLOCK_OUT", Net)
 

--- a/Oscillator/MAX7375AXR405.zen
+++ b/Oscillator/MAX7375AXR405.zen
@@ -57,7 +57,7 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-CLOCK_OUT = io("CLOCK_OUT", Net, default=Net("CLK_4MHZ"))
+CLOCK_OUT = io("CLOCK_OUT", Net)
 
 # Internal nets
 if add_series_termination:
@@ -67,7 +67,7 @@ else:
 
 # Power supply net (filtered or direct)
 if power_supply_config == PowerSupplyConfiguration("Noisy"):
-    _VCC_CHIP = Net("VCC_FILTERED")
+    _VCC_CHIP = Power("VCC_FILTERED")
 else:
     _VCC_CHIP = VCC
 

--- a/Oscillator/MAX7375AXR405.zen
+++ b/Oscillator/MAX7375AXR405.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ if add_series_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 CLOCK_OUT = io("CLOCK_OUT", Net)
 

--- a/Oscillator/MAX7375AXR425.zen
+++ b/Oscillator/MAX7375AXR425.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ if add_series_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 CLOCK_OUT = io("CLOCK_OUT", Net)
 

--- a/Oscillator/MAX7375AXR425.zen
+++ b/Oscillator/MAX7375AXR425.zen
@@ -57,7 +57,7 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-CLOCK_OUT = io("CLOCK_OUT", Net, default=Net("CLK_4M19"))
+CLOCK_OUT = io("CLOCK_OUT", Net)
 
 # Internal nets
 if add_series_termination:
@@ -67,7 +67,7 @@ else:
 
 # Power supply net (filtered or direct)
 if power_supply_config == PowerSupplyConfiguration("Noisy"):
-    _VCC_CHIP = Net("VCC_FILTERED")
+    _VCC_CHIP = Power("VCC_FILTERED")
 else:
     _VCC_CHIP = VCC
 

--- a/Oscillator/MAX7375AXR805.zen
+++ b/Oscillator/MAX7375AXR805.zen
@@ -57,7 +57,7 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-CLOCK_OUT = io("CLOCK_OUT", Net, default=Net("CLK_8MHZ"))
+CLOCK_OUT = io("CLOCK_OUT", Net)
 
 # Internal nets
 if add_series_termination:
@@ -67,7 +67,7 @@ else:
 
 # Power supply net (filtered or direct)
 if power_supply_config == PowerSupplyConfiguration("Noisy"):
-    _VCC_CHIP = Net("VCC_FILTERED")
+    _VCC_CHIP = Power("VCC_FILTERED")
 else:
     _VCC_CHIP = VCC
 

--- a/Oscillator/MAX7375AXR805.zen
+++ b/Oscillator/MAX7375AXR805.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -55,7 +54,7 @@ if add_series_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 CLOCK_OUT = io("CLOCK_OUT", Net)
 

--- a/Power_Management/LM5050-1.zen
+++ b/Power_Management/LM5050-1.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm5050-1.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -53,7 +52,7 @@ off_control = config("off_control", OffControl, default="PullDown")
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("5V to 75V"))
+VIN = io("VIN", Power(voltage="5V to 75V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Power_Management/LM5050-2.zen
+++ b/Power_Management/LM5050-2.zen
@@ -65,12 +65,15 @@ else:
 # nFGD control IO (specific to LM5050-2)
 if nfgd_control == NFGDControl("VLOGIC"):
     VLOGIC = io("VLOGIC", Power)
+    _FGD = Net("FGD")
 elif nfgd_control == NFGDControl("UserDefined"):
     FGD = io("FGD", Net)
+    _FGD = FGD
+else:
+    _FGD = Net("FGD")
 
 # Internal nets
 _GATE = Net("GATE")
-_FGD = Net("FGD")
 
 # High side OR-ing FET controller, 6V to 75V operation, TSOT-23-6
 Component(
@@ -99,9 +102,6 @@ elif off_control == OffControl("UserDefined"):
 if nfgd_control == NFGDControl("VLOGIC"):
     # Pull-up resistor to VLOGIC for FGD pin (active low output)
     Resistor(name="R_FGD", value="100kohms", package="0402", P1=_FGD, P2=VLOGIC)
-elif nfgd_control == NFGDControl("UserDefined"):
-    # FGD pin exposed for user-defined control
-    FGD = _FGD
 
 # Fixed MOSFET configuration
 

--- a/Power_Management/LM5050-2.zen
+++ b/Power_Management/LM5050-2.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm5050-2.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -51,7 +50,7 @@ nfgd_control = config("nfgd_control", NFGDControl, default="VLOGIC")
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("6V to 75V"))
+VIN = io("VIN", Power(voltage="6V to 75V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Power_Management/MAX9612.zen
+++ b/Power_Management/MAX9612.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -76,7 +75,7 @@ if add_set_divider:
 add_test_points = config("add_test_points", bool, default=True, optional=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # Current sense inputs

--- a/Power_Management/TPS2065CDBV.zen
+++ b/Power_Management/TPS2065CDBV.zen
@@ -27,7 +27,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/tps2065c.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -60,7 +59,7 @@ add_input_tvs = config("add_input_tvs", bool, default=True)
 add_output_tvs = config("add_output_tvs", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("4.5V to 5.5V"))
+VIN = io("VIN", Power(voltage="4.5V to 5.5V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Power_Management/TPS2065CDBV.zen
+++ b/Power_Management/TPS2065CDBV.zen
@@ -169,7 +169,6 @@ elif enable_config == PinConfig("PullDown"):
 
 # Optional input TVS diode for ESD protection
 if add_input_tvs:
-    Diode = Module("@stdlib/generics/Diode.zen")
     Diode(
         name="D_TVS_IN",
         variant="Zener",  # TVS diodes are similar to Zener

--- a/RF_Amplifier/PGA-102.zen
+++ b/RF_Amplifier/PGA-102.zen
@@ -63,22 +63,20 @@ add_output_protection = config("add_output_protection", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, default=Power("VDD"))
+VDD = io("VDD", Power)
 GND = io("GND", Ground)
 RFIN = io("RFIN", Net)
 RFOUT = io("RFOUT", Net)
 
 # Internal nets
-_VDD_FILT = Net("VDD_FILT")  # Filtered power supply
+_VDD_FILT = Power("VDD_FILT") if add_ferrite_bead else VDD  # Filtered power supply
 _RFIN_INT = Net("RFIN_INT")  # Internal RF input after DC blocking
-_RFOUT_INT = Net("RFOUT_INT")  # Internal RF output before DC blocking
+_RFOUT_INT = RFOUT  # Chip-side RF output; C_OUT DC-blocks from _BIAS_NODE onto RFOUT
 _BIAS_NODE = Net("BIAS_NODE")  # Bias injection point
 
 # Power supply filtering
 if add_ferrite_bead:
     FerriteBead(name="FB1", package="0805", P1=VDD, P2=_VDD_FILT)
-else:
-    _VDD_FILT = VDD
 
 # Bulk capacitor - use 0.1uF as per datasheet
 Capacitor(name="C_BULK", value="100nF", voltage="10V", package="0805", P1=_VDD_FILT, P2=GND, dnp=not add_bulk_cap)
@@ -157,8 +155,7 @@ if add_output_protection:
         pins={"A1": _RFOUT_INT, "A2": GND},
     )
 
-# Connect output
-_RFOUT_INT = RFOUT
+# Output is the external RFOUT io directly; no further alias needed.
 
 # Test points
 if add_test_points:

--- a/RF_Amplifier/PGA-1021.zen
+++ b/RF_Amplifier/PGA-1021.zen
@@ -68,22 +68,20 @@ if add_input_termination:
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, default=Power("VDD"))
+VDD = io("VDD", Power)
 GND = io("GND", Ground)
 RFIN = io("RFIN", Net)
 RFOUT = io("RFOUT", Net)
 
 # Internal nets
-_VDD_FILT = Net("VDD_FILT")  # Filtered power supply
+_VDD_FILT = Power("VDD_FILT") if add_ferrite_bead else VDD  # Filtered power supply
 _RFIN_INT = Net("RFIN_INT")  # Internal RF input after DC blocking
-_RFOUT_INT = Net("RFOUT_INT")  # Internal RF output before DC blocking
+_RFOUT_INT = RFOUT  # Chip-side RF output; C_OUT DC-blocks onto the external RFOUT io
 _BIAS_NODE = Net("BIAS_NODE")  # Bias injection point
 
 # Power supply filtering
 if add_ferrite_bead:
     FerriteBead(name="FB1", package="0805", P1=VDD, P2=_VDD_FILT)
-else:
-    _VDD_FILT = VDD
 
 # Bulk capacitor - use 0.1uF as per datasheet
 Capacitor(name="C_BULK", value="100nF", voltage="10V", package="0805", P1=_VDD_FILT, P2=GND, dnp=not add_bulk_cap)
@@ -168,8 +166,7 @@ if add_output_protection:
         pins={"A1": _RFOUT_INT, "A2": GND},
     )
 
-# Connect output
-_RFOUT_INT = RFOUT
+# Output is the external RFOUT io directly; no further alias needed.
 
 # Test points
 if add_test_points:

--- a/RF_Amplifier/PGA-103.zen
+++ b/RF_Amplifier/PGA-103.zen
@@ -68,22 +68,20 @@ add_stability_network = config("add_stability_network", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, default=Power("VDD"))
+VDD = io("VDD", Power)
 GND = io("GND", Ground)
 RFIN = io("RFIN", Net)
 RFOUT = io("RFOUT", Net)
 
 # Internal nets
-_VDD_FILT = Net("VDD_FILT")  # Filtered power supply
+_VDD_FILT = Power("VDD_FILT") if add_ferrite_bead else VDD  # Filtered power supply
 _RFIN_INT = Net("RFIN_INT")  # Internal RF input after DC blocking
-_RFOUT_INT = Net("RFOUT_INT")  # Internal RF output before DC blocking
+_RFOUT_INT = RFOUT  # Chip-side RF output; C_OUT DC-blocks onto the external RFOUT io
 _BIAS_NODE = Net("BIAS_NODE")  # Bias injection point
 
 # Power supply filtering
 if add_ferrite_bead:
     FerriteBead(name="FB1", package="0805", P1=VDD, P2=_VDD_FILT)
-else:
-    _VDD_FILT = VDD
 
 # Bulk capacitor - 10uF for PGA-103 as per application circuit
 Capacitor(name="C_BULK", value="10uF", voltage="10V", package="1206", P1=_VDD_FILT, P2=GND, dnp=not add_bulk_cap)
@@ -167,8 +165,7 @@ if add_output_protection:
         pins={"A1": _RFOUT_INT, "A2": GND},
     )
 
-# Connect output
-_RFOUT_INT = RFOUT
+# Output is the external RFOUT io directly; no further alias needed.
 
 # Test points
 if add_test_points:

--- a/RF_Amplifier/PGA-106-75.zen
+++ b/RF_Amplifier/PGA-106-75.zen
@@ -56,13 +56,13 @@ add_output_protection = config("add_output_protection", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, default=Power("VDD"))
+VDD = io("VDD", Power)
 GND = io("GND", Ground)
 RFIN = io("RFIN", Net)
 RFOUT = io("RFOUT", Net)
 
 # Internal nets
-_VDD_FILT = Net("VDD_FILT")  # Filtered power supply
+_VDD_FILT = Power("VDD_FILT") if add_ferrite_bead else VDD  # Filtered power supply
 _RFIN_INT = Net("RFIN_INT")  # Internal RF input after DC blocking
 _BIAS_NODE = Net("BIAS_NODE")  # Bias injection point
 _RFIN_MATCHED = Net("RFIN_MATCHED")  # Input after matching network
@@ -71,8 +71,6 @@ _RFOUT_MATCHED = Net("RFOUT_MATCHED")  # Output before matching network
 # Power supply filtering
 if add_ferrite_bead:
     FerriteBead(name="FB1", package="0805", P1=VDD, P2=_VDD_FILT)
-else:
-    _VDD_FILT = VDD
 
 # Bulk capacitor
 Capacitor(name="C_BULK", value="0.1uF", voltage="10V", package="0805", P1=_VDD_FILT, P2=GND, dnp=not add_bulk_cap)

--- a/RF_Amplifier/PGA-106R-75.zen
+++ b/RF_Amplifier/PGA-106R-75.zen
@@ -63,22 +63,20 @@ add_output_protection = config("add_output_protection", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, default=Power("VDD"))
+VDD = io("VDD", Power)
 GND = io("GND", Ground)
 RFIN = io("RFIN", Net)
 RFOUT = io("RFOUT", Net)
 
 # Internal nets
-_VDD_FILT = Net("VDD_FILT")  # Filtered power supply
+_VDD_FILT = Power("VDD_FILT") if add_ferrite_bead else VDD  # Filtered power supply
 _RFIN_INT = Net("RFIN_INT")  # Internal RF input after DC blocking
-_RFOUT_INT = Net("RFOUT_INT")  # Internal RF output before DC blocking
+_RFOUT_INT = RFOUT  # Chip-side RF output; C_OUT DC-blocks onto the external RFOUT io
 _BIAS_NODE = Net("BIAS_NODE")  # Bias injection point
 
 # Power supply filtering
 if add_ferrite_bead:
     FerriteBead(name="FB1", package="0805", P1=VDD, P2=_VDD_FILT)
-else:
-    _VDD_FILT = VDD
 
 # Bulk capacitor - use 10uF for lower frequency operation
 Capacitor(name="C_BULK", value="10uF", voltage="10V", package="0805", P1=_VDD_FILT, P2=GND, dnp=not add_bulk_cap)
@@ -157,8 +155,7 @@ if add_output_protection:
         pins={"A1": _RFOUT_INT, "A2": GND},
     )
 
-# Connect output
-_RFOUT_INT = RFOUT
+# Output is the external RFOUT io directly; no further alias needed.
 
 # Test points
 if add_test_points:

--- a/RF_GPS/NEO-M8M.zen
+++ b/RF_GPS/NEO-M8M.zen
@@ -13,7 +13,6 @@ Datasheet: https://content.u-blox.com/sites/default/files/NEO-M8-FW3_DataSheet_U
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -52,8 +51,8 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO - Always create these power nets
-VCC = io("VCC", Power, checks=voltage_within("1.65V to 3.6V"))
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VCC = io("VCC", Power(voltage="1.65V to 3.6V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 GND = io("GND", Ground)
 
 # Interface IO - conditional based on configuration

--- a/RF_GPS/NEO-M8M.zen
+++ b/RF_GPS/NEO-M8M.zen
@@ -72,7 +72,7 @@ TIMEPULSE = io("TIMEPULSE", Net)
 EXTINT = io("EXTINT", Net)
 
 # Internal nets
-_VCC_RF = Net("VCC_RF")
+_VCC_RF = Power("VCC_RF")
 _RF_IN = Net("RF_IN")
 _D_SEL = Net("D_SEL")
 _SAFEBOOT_N = Net("SAFEBOOT_N")
@@ -85,7 +85,6 @@ else:
     _RESET_N = Net("RESET_N")
 
 # Reserved pins
-_RESERVED = Net("RESERVED")
 
 # Interface pins based on mode
 if interface_mode == InterfaceMode("UART_I2C"):
@@ -103,16 +102,15 @@ else:  # SPI mode
 # _V_BCKP connects to the NEO-M8M's V_BCKP pin
 if add_battery:
     # When battery is enabled, create a separate net for backup voltage
-    _V_BCKP = Net("V_BCKP")
+    _V_BCKP = Power("V_BCKP")
 else:
     # When battery is disabled, connect backup voltage to VCC
     _V_BCKP = VCC
 
 # Define initial USB data nets
 if add_usb:
-    # These will be replaced/connected in the USB circuit section
-    _USB_DM = Net("USB_DM")
-    _USB_DP = Net("USB_DP")
+    _USB_DM = usb.D.N
+    _USB_DP = usb.D.P
 else:
     _USB_DM = Net("USB_DM_NC")
     _USB_DP = Net("USB_DP_NC")
@@ -134,7 +132,6 @@ NEO_M8M = Component(
         "VCC_RF": _VCC_RF,
         "GND": GND,
         "RF_IN": _RF_IN,
-        "RESERVED": _RESERVED,  # Pin 14 (LNA_EN on other variants, reserved on M8M)
         "VCC": VCC,
         "V_BCKP": _V_BCKP,
         "TXD/SPI_MISO": _TXD if interface_mode == InterfaceMode("UART_I2C") else _SPI_MISO,
@@ -349,8 +346,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VCC
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VBUS),
-            VOUT=Power(NET=VCC),
+            VIN=Power(VBUS),
+            VOUT=Power(VCC),
             GND=GND,
             add_input_cap=add_decoupling_caps,
             add_output_cap=add_decoupling_caps,

--- a/RF_GPS/NEO-M8N.zen
+++ b/RF_GPS/NEO-M8N.zen
@@ -72,7 +72,7 @@ EXTINT = io("EXTINT", Net)
 LNA_EN = io("LNA_EN", Net)
 
 # Internal nets
-_VCC_RF = Net("VCC_RF")
+_VCC_RF = Power("VCC_RF")
 _RF_IN = Net("RF_IN")
 _D_SEL = Net("D_SEL")
 _SAFEBOOT_N = Net("SAFEBOOT_N")
@@ -85,7 +85,6 @@ else:
     _RESET_N = Net("RESET_N")
 
 # Reserved pins
-_RESERVED = Net("RESERVED")
 
 # Interface pins based on mode
 if interface_mode == InterfaceMode("UART_I2C"):
@@ -103,16 +102,15 @@ else:  # SPI mode
 # _V_BCKP connects to the NEO-M8N's V_BCKP pin
 if add_battery:
     # When battery is enabled, create a separate net for backup voltage
-    _V_BCKP = Net("V_BCKP")
+    _V_BCKP = Power("V_BCKP")
 else:
     # When battery is disabled, connect backup voltage to VCC
     _V_BCKP = VCC
 
 # Define initial USB data nets
 if add_usb:
-    # These will be replaced/connected in the USB circuit section
-    _USB_DM = Net("USB_DM")
-    _USB_DP = Net("USB_DP")
+    _USB_DM = usb.D.N
+    _USB_DP = usb.D.P
 else:
     _USB_DM = Net("USB_DM_NC")
     _USB_DP = Net("USB_DP_NC")
@@ -134,7 +132,6 @@ NEO_M8N = Component(
         "VCC_RF": _VCC_RF,
         "RF_IN": _RF_IN,
         "LNA_EN": LNA_EN,
-        "RESERVED": _RESERVED,  # Pins 15-17 all reserved
         "VCC": VCC,
         "V_BCKP": _V_BCKP,
         "GND": GND,
@@ -349,8 +346,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VCC
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VBUS),
-            VOUT=Power(NET=VCC),
+            VIN=Power(VBUS),
+            VOUT=Power(VCC),
             GND=GND,
             add_input_cap=add_decoupling_caps,
             add_output_cap=add_decoupling_caps,

--- a/RF_GPS/NEO-M8N.zen
+++ b/RF_GPS/NEO-M8N.zen
@@ -12,7 +12,6 @@ Datasheet: https://www.u-blox.com/sites/default/files/NEO-M8-FW3_DataSheet_UBX-1
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -51,8 +50,8 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO - Always create these power nets
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 GND = io("GND", Ground)
 
 # Interface IO - conditional based on configuration

--- a/RF_GPS/NEO-M8P.zen
+++ b/RF_GPS/NEO-M8P.zen
@@ -16,7 +16,6 @@ Datasheet: https://content.u-blox.com/sites/default/files/NEO-M8P_DataSheet_UBX-
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -57,8 +56,8 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO - Always create these power nets
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 GND = io("GND", Ground)
 
 # Interface IO - conditional based on configuration

--- a/RF_GPS/NEO-M8P.zen
+++ b/RF_GPS/NEO-M8P.zen
@@ -80,7 +80,7 @@ RTK_STAT = io("RTK_STAT", Net)
 GEOFENCE_STAT = io("GEOFENCE_STAT", Net)
 
 # Internal nets
-_VCC_RF = Net("VCC_RF")
+_VCC_RF = Power("VCC_RF")
 _RF_IN = Net("RF_IN")
 _D_SEL = Net("D_SEL")
 _SAFEBOOT_N = Net("SAFEBOOT_N")
@@ -93,7 +93,6 @@ else:
     _RESET_N = Net("RESET_N")
 
 # Reserved pins
-_RESERVED = Net("RESERVED")
 
 # Interface pins based on mode
 if interface_mode == InterfaceMode("UART_I2C"):
@@ -111,16 +110,15 @@ else:  # SPI mode
 # _V_BCKP connects to the NEO-M8P's V_BCKP pin
 if add_battery:
     # When battery is enabled, create a separate net for backup voltage
-    _V_BCKP = Net("V_BCKP")
+    _V_BCKP = Power("V_BCKP")
 else:
     # When battery is disabled, connect backup voltage to VCC
     _V_BCKP = VCC
 
 # Define initial USB data nets
 if add_usb:
-    # These will be replaced/connected in the USB circuit section
-    _USB_DM = Net("USB_DM")
-    _USB_DP = Net("USB_DP")
+    _USB_DM = usb.D.N
+    _USB_DP = usb.D.P
 else:
     _USB_DM = Net("USB_DM_NC")
     _USB_DP = Net("USB_DP_NC")
@@ -145,7 +143,6 @@ NEO_M8P = Component(
         "LNA_EN": LNA_EN,
         "RTK_STAT": RTK_STAT,
         "GEOFENCE_STAT": GEOFENCE_STAT,
-        "RESERVED": _RESERVED,  # Pin 15
         "VCC": VCC,
         "V_BCKP": _V_BCKP,
         "TXD/SPI_MISO": _TXD if interface_mode == InterfaceMode("UART_I2C") else _SPI_MISO,
@@ -384,8 +381,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VCC
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VBUS),
-            VOUT=Power(NET=VCC),
+            VIN=Power(VBUS),
+            VOUT=Power(VCC),
             GND=GND,
             add_input_cap=add_decoupling_caps,
             add_output_cap=add_decoupling_caps,

--- a/RF_GPS/NEO-M8Q.zen
+++ b/RF_GPS/NEO-M8Q.zen
@@ -13,7 +13,6 @@ Datasheet: https://content.u-blox.com/sites/default/files/NEO-M8-FW3_DataSheet_U
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -52,8 +51,8 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO - Always create these power nets
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 GND = io("GND", Ground)
 
 # Interface IO - conditional based on configuration

--- a/RF_GPS/NEO-M8Q.zen
+++ b/RF_GPS/NEO-M8Q.zen
@@ -73,7 +73,7 @@ EXTINT = io("EXTINT", Net)
 LNA_EN = io("LNA_EN", Net)
 
 # Internal nets
-_VCC_RF = Net("VCC_RF")
+_VCC_RF = Power("VCC_RF")
 _RF_IN = Net("RF_IN")
 _D_SEL = Net("D_SEL")
 _SAFEBOOT_N = Net("SAFEBOOT_N")
@@ -86,7 +86,6 @@ else:
     _RESET_N = Net("RESET_N")
 
 # Reserved pins
-_RESERVED = Net("RESERVED")
 
 # Interface pins based on mode
 if interface_mode == InterfaceMode("UART_I2C"):
@@ -104,16 +103,15 @@ else:  # SPI mode
 # _V_BCKP connects to the NEO-M8Q's V_BCKP pin
 if add_battery:
     # When battery is enabled, create a separate net for backup voltage
-    _V_BCKP = Net("V_BCKP")
+    _V_BCKP = Power("V_BCKP")
 else:
     # When battery is disabled, connect backup voltage to VCC
     _V_BCKP = VCC
 
 # Define initial USB data nets
 if add_usb:
-    # These will be replaced/connected in the USB circuit section
-    _USB_DM = Net("USB_DM")
-    _USB_DP = Net("USB_DP")
+    _USB_DM = usb.D.N
+    _USB_DP = usb.D.P
 else:
     _USB_DM = Net("USB_DM_NC")
     _USB_DP = Net("USB_DP_NC")
@@ -136,7 +134,6 @@ NEO_M8Q = Component(
         "GND": GND,
         "RF_IN": _RF_IN,
         "LNA_EN": LNA_EN,
-        "RESERVED": _RESERVED,  # Pin 15
         "VCC": VCC,
         "V_BCKP": _V_BCKP,
         "TXD/SPI_MISO": _TXD if interface_mode == InterfaceMode("UART_I2C") else _SPI_MISO,
@@ -350,8 +347,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VCC
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VBUS),
-            VOUT=Power(NET=VCC),
+            VIN=Power(VBUS),
+            VOUT=Power(VCC),
             GND=GND,
             add_input_cap=add_decoupling_caps,
             add_output_cap=add_decoupling_caps,

--- a/RF_GPS/NEO-M8T.zen
+++ b/RF_GPS/NEO-M8T.zen
@@ -13,7 +13,6 @@ Datasheet: https://content.u-blox.com/sites/default/files/NEO-LEA-M8T-FW3_DataSh
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -52,8 +51,8 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO - Always create these power nets
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 GND = io("GND", Ground)
 
 # Interface IO - conditional based on configuration

--- a/RF_GPS/NEO-M8T.zen
+++ b/RF_GPS/NEO-M8T.zen
@@ -74,7 +74,7 @@ EXTINT1 = io("EXTINT1", Net)  # Second external interrupt (timing specific)
 LNA_EN = io("LNA_EN", Net)
 
 # Internal nets
-_VCC_RF = Net("VCC_RF")
+_VCC_RF = Power("VCC_RF")
 _RF_IN = Net("RF_IN")
 _D_SEL = Net("D_SEL")
 _SAFEBOOT_N = Net("SAFEBOOT_N")
@@ -87,7 +87,6 @@ else:
     _RESET_N = Net("RESET_N")
 
 # Reserved pins
-_RESERVED = Net("RESERVED")
 
 # Interface pins based on mode
 if interface_mode == InterfaceMode("UART_I2C"):
@@ -105,16 +104,15 @@ else:  # SPI mode
 # _V_BCKP connects to the NEO-M8T's V_BCKP pin
 if add_battery:
     # When battery is enabled, create a separate net for backup voltage
-    _V_BCKP = Net("V_BCKP")
+    _V_BCKP = Power("V_BCKP")
 else:
     # When battery is disabled, connect backup voltage to VCC
     _V_BCKP = VCC
 
 # Define initial USB data nets
 if add_usb:
-    # These will be replaced/connected in the USB circuit section
-    _USB_DM = Net("USB_DM")
-    _USB_DP = Net("USB_DP")
+    _USB_DM = usb.D.N
+    _USB_DP = usb.D.P
 else:
     _USB_DM = Net("USB_DM_NC")
     _USB_DP = Net("USB_DP_NC")
@@ -138,7 +136,6 @@ NEO_M8T = Component(
         "RF_IN": _RF_IN,  # Pin 11
         "LNA_EN": LNA_EN,  # Pin 14
         "EXTINT1": EXTINT1,  # Pin 15 - Second external interrupt
-        "RESERVED": _RESERVED,  # Pins 16, 17
         "SDA/~{SPI_CS}": _SDA if interface_mode == InterfaceMode("UART_I2C") else _SPI_CS_N,  # Pin 18
         "SCL/SPI_CLK": _SCL if interface_mode == InterfaceMode("UART_I2C") else _SPI_CLK,  # Pin 19
         "TXD/SPI_MISO": _TXD if interface_mode == InterfaceMode("UART_I2C") else _SPI_MISO,  # Pin 20
@@ -355,8 +352,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VCC
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VBUS),
-            VOUT=Power(NET=VCC),
+            VIN=Power(VBUS),
+            VOUT=Power(VCC),
             GND=GND,
             add_input_cap=add_decoupling_caps,
             add_output_cap=add_decoupling_caps,

--- a/RF_GPS/NEO-M9N.zen
+++ b/RF_GPS/NEO-M9N.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.u-blox.com/sites/default/files/NEO-M9N-00B_DataSheet_UBX-
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Uart", "Usb2", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -52,8 +51,8 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO - Always create these power nets
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
-VBUS = io("VBUS", Power, checks=voltage_within("4V to 5.5V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
+VBUS = io("VBUS", Power(voltage="4V to 5.5V"))
 GND = io("GND", Ground)
 
 # Interface IO - conditional based on configuration

--- a/RF_GPS/NEO-M9N.zen
+++ b/RF_GPS/NEO-M9N.zen
@@ -73,7 +73,7 @@ EXTINT = io("EXTINT", Net)
 LNA_EN = io("LNA_EN", Net)
 
 # Internal nets
-_VCC_RF = Net("VCC_RF")
+_VCC_RF = Power("VCC_RF")
 _RF_IN = Net("RF_IN")
 _D_SEL = Net("D_SEL")
 _SAFEBOOT_N = Net("SAFEBOOT_N")
@@ -86,7 +86,6 @@ else:
     _RESET_N = Net("RESET_N")
 
 # Reserved pins
-_RESERVED = Net("RESERVED")
 
 # Interface pins based on mode
 if interface_mode == InterfaceMode("UART_I2C"):
@@ -104,16 +103,15 @@ else:  # SPI mode
 # _V_BCKP connects to the NEO-M9N's V_BCKP pin
 if add_battery:
     # When battery is enabled, create a separate net for backup voltage
-    _V_BCKP = Net("V_BCKP")
+    _V_BCKP = Power("V_BCKP")
 else:
     # When battery is disabled, connect backup voltage to VCC
     _V_BCKP = VCC
 
 # Define initial USB data nets
 if add_usb:
-    # These will be replaced/connected in the USB circuit section
-    _USB_DM = Net("USB_DM")
-    _USB_DP = Net("USB_DP")
+    _USB_DM = usb.D.N
+    _USB_DP = usb.D.P
 else:
     _USB_DM = Net("USB_DM_NC")
     _USB_DP = Net("USB_DP_NC")
@@ -136,7 +134,6 @@ NEO_M9N = Component(
         "GND": GND,
         "RF_IN": _RF_IN,
         "LNA_EN": LNA_EN,
-        "RESERVED": _RESERVED,  # Pin 15
         "VCC": VCC,
         "V_BCKP": _V_BCKP,
         "TXD/SPI_MISO": _TXD if interface_mode == InterfaceMode("UART_I2C") else _SPI_MISO,
@@ -348,8 +345,8 @@ if add_usb:
         # 3.3V LDO regulator from USB 5V to VCC
         AP2112K_3_3(
             name="U_USB_REG",
-            VIN=Power(NET=VBUS),
-            VOUT=Power(NET=VCC),
+            VIN=Power(VBUS),
+            VOUT=Power(VCC),
             GND=GND,
             add_input_cap=add_decoupling_caps,
             add_output_cap=add_decoupling_caps,

--- a/RF_GPS/SAM-M8Q.zen
+++ b/RF_GPS/SAM-M8Q.zen
@@ -15,7 +15,6 @@ Datasheet: https://content.u-blox.com/sites/default/files/SAM-M8Q_DataSheet_UBX-
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Uart", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -45,7 +44,7 @@ add_decoupling = config("add_decoupling", bool, default=True)
 enable_safeboot_pins = config("enable_safeboot_pins", bool, default=True)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
+VCC = io("VCC", Power(voltage="2.7V to 3.6V"))
 _VCC_IO_REQ = io("VCC_IO", Power, optional=True)
 VCC_IO = _VCC_IO_REQ if _VCC_IO_REQ != None else VCC
 GND = io("GND", Ground)

--- a/RF_GPS/SAM-M8Q.zen
+++ b/RF_GPS/SAM-M8Q.zen
@@ -46,7 +46,8 @@ enable_safeboot_pins = config("enable_safeboot_pins", bool, default=True)
 
 # External IO
 VCC = io("VCC", Power, checks=voltage_within("2.7V to 3.6V"))
-VCC_IO = io("VCC_IO", Net, default=VCC)
+_VCC_IO_REQ = io("VCC_IO", Power, optional=True)
+VCC_IO = _VCC_IO_REQ if _VCC_IO_REQ != None else VCC
 GND = io("GND", Ground)
 
 # Interface IO
@@ -61,21 +62,21 @@ TIMEPULSE = io("TIMEPULSE", Net, optional=True)
 EXTINT = io("EXTINT", Net, optional=True)
 
 # Internal nets
-_V_BCKP = io("V_BCKP", Net) if add_backup_battery else VCC_IO
+_V_BCKP = io("V_BCKP", Power) if add_backup_battery else VCC_IO
 _RESET_N = Net("RESET_N")
 _SAFEBOOT_N = Net("SAFEBOOT_N")
-_SDA = Net("SDA")
-_SCL = Net("SCL")
-_TXD = Net("TXD")
-_RXD = Net("RXD")
 
 # Connect interface nets based on configuration
 if interface_mode == InterfaceMode("UART"):
     _TXD = uart.TX
     _RXD = uart.RX
+    _SDA = Net("SDA")
+    _SCL = Net("SCL")
 elif interface_mode == InterfaceMode("I2C"):
     _SDA = i2c.SDA
     _SCL = i2c.SCL
+    _TXD = Net("TXD")
+    _RXD = Net("RXD")
 else:  # Both
     _TXD = uart.TX
     _RXD = uart.RX
@@ -109,9 +110,6 @@ if add_backup_battery:
     Resistor(name="R_BACKUP", value="10ohms", package="0603", P1=VCC_IO, P2=_V_BCKP)
     # Backup capacitor
     Capacitor(name="C_BACKUP", value="1uF", voltage="6.3V", package="0603", P1=_V_BCKP, P2=GND)
-else:
-    # Connect V_BCKP directly to VCC_IO
-    _V_BCKP = VCC_IO
 
 # Pulse LED on TIMEPULSE
 if add_pulse_led and TIMEPULSE:

--- a/RF_Module/RFM69HW.zen
+++ b/RF_Module/RFM69HW.zen
@@ -27,7 +27,7 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO
-VDD = io("VDD_3V3", Power, default=Power("VDD_3V3"))
+VDD = io("VDD_3V3", Power)
 GND = io("GND", Ground)
 
 # SPI Interface
@@ -67,7 +67,6 @@ Component(
         "MISO": spi.MISO,
         "MOSI": spi.MOSI,
         "NSS": spi.CS,
-        "NC": GND,  # NC pin should be connected to GND per datasheet
     },
 )
 

--- a/RF_Module/RFM69W.zen
+++ b/RF_Module/RFM69W.zen
@@ -27,7 +27,7 @@ add_bulk_caps = config("add_bulk_caps", bool, default=True)
 add_decoupling_caps = config("add_decoupling_caps", bool, default=True)
 
 # External IO
-VDD = io("VDD_3V3", Power, default=Power("VDD_3V3"))
+VDD = io("VDD_3V3", Power)
 GND = io("GND", Ground)
 
 # SPI Interface
@@ -67,7 +67,6 @@ Component(
         "MISO": spi.MISO,
         "MOSI": spi.MOSI,
         "NSS": spi.CS,
-        "NC": GND,  # NC pin should be connected to GND per datasheet
     },
 )
 

--- a/Reference_Voltage/LM4125IM5-2.5.zen
+++ b/Reference_Voltage/LM4125IM5-2.5.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm4125.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance")
 
 # Dependencies
@@ -25,19 +25,16 @@ add_output_cap = config("add_output_cap", bool, default=True)
 output_cap_value = config("output_cap_value", Capacitance, default="22nF")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
-
-# Internal nets
-_NC = NotConnected()
 
 # 2.5V ±0.5% Precision Micropower Low Dropout Voltage Reference, SOT-23-5
 Component(
     name="LM4125IM5_2V5",
     symbol=Symbol(library="@kicad-symbols/Reference_Voltage.kicad_sym", name="LM4125IM5-2.5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"Vin": VIN, "GND": GND, "NC": _NC, "Vout": VOUT},
+    pins={"Vin": VIN, "GND": GND, "Vout": VOUT},
 )
 
 # Output Capacitor - Required minimum 22nF ceramic for stability

--- a/Reference_Voltage/LM4128.zen
+++ b/Reference_Voltage/LM4128.zen
@@ -14,7 +14,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm4128.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,21 +33,18 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VREF = io("VREF", Net, default=Net("VREF"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VREF = io("VREF", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
-
-# Internal nets
-_NC = NotConnected()
 
 # 2.5V ±0.2% Precision Micropower Low Dropout Voltage Reference, SOT-23-5
 Component(
     name="LM4128",
     symbol=Symbol(library="@kicad-symbols/Reference_Voltage.kicad_sym", name="LM4128"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"VIN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "VREF": VREF},
+    pins={"VIN": VIN, "EN": EN_CTRL, "GND": GND, "VREF": VREF},
 )
 
 # Input Capacitor - Required per datasheet, minimum 0.1µF

--- a/Reference_Voltage/LM4132.zen
+++ b/Reference_Voltage/LM4132.zen
@@ -14,7 +14,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm4132.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -27,20 +27,19 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VREF = io("VREF", Net, default=Net("VREF"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VREF = io("VREF", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # Precision Low Dropout Voltage Reference, 4.096V, ±0.05% to ±0.5%, SOT-23-5
 Component(
     name="LM4132",
     symbol=Symbol(library="@kicad-symbols/Reference_Voltage.kicad_sym", name="LM4132xMF-4.1"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"VIN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "VREF": VREF},
+    pins={"VIN": VIN, "EN": EN_CTRL, "GND": GND, "VREF": VREF},
 )
 
 # Input Capacitor - Required for stable operation (minimum 0.1µF)

--- a/Reference_Voltage/MAX6001.zen
+++ b/Reference_Voltage/MAX6001.zen
@@ -56,11 +56,11 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VIN = io("VIN", Power, checks=voltage_within("2.5V to 12.6V"))
 GND = io("GND", Ground)
-VREF = io("VREF", Net, default=Net("VREF_1V25"))
+VREF = io("VREF", Power)
 
 # Internal nets
 if input_filter_config == InputFilterConfiguration("RC"):
-    _VIN_FILTERED = Net("VIN_FILTERED")
+    _VIN_FILTERED = Power("VIN_FILTERED")
 else:
     _VIN_FILTERED = VIN
 

--- a/Reference_Voltage/MAX6001.zen
+++ b/Reference_Voltage/MAX6001.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -54,7 +53,7 @@ if output_config == OutputConfiguration("Filtered"):
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.5V to 12.6V"))
+VIN = io("VIN", Power(voltage="2.5V to 12.6V"))
 GND = io("GND", Ground)
 VREF = io("VREF", Power)
 

--- a/Reference_Voltage/MAX6002.zen
+++ b/Reference_Voltage/MAX6002.zen
@@ -56,11 +56,11 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VIN = io("VIN", Power, checks=voltage_within("2.7V to 12.6V"))
 GND = io("GND", Ground)
-VREF = io("VREF", Net, default=Net("VREF_2V5"))
+VREF = io("VREF", Power)
 
 # Internal nets
 if input_filter_config == InputFilterConfiguration("RC"):
-    _VIN_FILTERED = Net("VIN_FILTERED")
+    _VIN_FILTERED = Power("VIN_FILTERED")
 else:
     _VIN_FILTERED = VIN
 

--- a/Reference_Voltage/MAX6002.zen
+++ b/Reference_Voltage/MAX6002.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -54,7 +53,7 @@ if output_config == OutputConfiguration("Filtered"):
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.7V to 12.6V"))
+VIN = io("VIN", Power(voltage="2.7V to 12.6V"))
 GND = io("GND", Ground)
 VREF = io("VREF", Power)
 

--- a/Reference_Voltage/MAX6003.zen
+++ b/Reference_Voltage/MAX6003.zen
@@ -56,11 +56,11 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VIN = io("VIN", Power, checks=voltage_within("3.2V to 12.6V"))
 GND = io("GND", Ground)
-VREF = io("VREF", Net, default=Net("VREF_3V0"))
+VREF = io("VREF", Power)
 
 # Internal nets
 if input_filter_config == InputFilterConfiguration("RC"):
-    _VIN_FILTERED = Net("VIN_FILTERED")
+    _VIN_FILTERED = Power("VIN_FILTERED")
 else:
     _VIN_FILTERED = VIN
 

--- a/Reference_Voltage/MAX6003.zen
+++ b/Reference_Voltage/MAX6003.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -54,7 +53,7 @@ if output_config == OutputConfiguration("Filtered"):
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("3.2V to 12.6V"))
+VIN = io("VIN", Power(voltage="3.2V to 12.6V"))
 GND = io("GND", Ground)
 VREF = io("VREF", Power)
 

--- a/Reference_Voltage/MAX6004.zen
+++ b/Reference_Voltage/MAX6004.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -54,7 +53,7 @@ if output_config == OutputConfiguration("Filtered"):
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("4.3V to 12.6V"))
+VIN = io("VIN", Power(voltage="4.3V to 12.6V"))
 GND = io("GND", Ground)
 VREF = io("VREF", Power)
 

--- a/Reference_Voltage/MAX6004.zen
+++ b/Reference_Voltage/MAX6004.zen
@@ -56,11 +56,11 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VIN = io("VIN", Power, checks=voltage_within("4.3V to 12.6V"))
 GND = io("GND", Ground)
-VREF = io("VREF", Net, default=Net("VREF_4V096"))
+VREF = io("VREF", Power)
 
 # Internal nets
 if input_filter_config == InputFilterConfiguration("RC"):
-    _VIN_FILTERED = Net("VIN_FILTERED")
+    _VIN_FILTERED = Power("VIN_FILTERED")
 else:
     _VIN_FILTERED = VIN
 

--- a/Reference_Voltage/MAX6005.zen
+++ b/Reference_Voltage/MAX6005.zen
@@ -56,11 +56,11 @@ add_test_points = config("add_test_points", bool, default=True)
 # External IO
 VIN = io("VIN", Power, checks=voltage_within("5.2V to 12.6V"))
 GND = io("GND", Ground)
-VREF = io("VREF", Net, default=Net("VREF_5V0"))
+VREF = io("VREF", Power)
 
 # Internal nets
 if input_filter_config == InputFilterConfiguration("RC"):
-    _VIN_FILTERED = Net("VIN_FILTERED")
+    _VIN_FILTERED = Power("VIN_FILTERED")
 else:
     _VIN_FILTERED = VIN
 

--- a/Reference_Voltage/MAX6005.zen
+++ b/Reference_Voltage/MAX6005.zen
@@ -25,7 +25,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -54,7 +53,7 @@ if output_config == OutputConfiguration("Filtered"):
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("5.2V to 12.6V"))
+VIN = io("VIN", Power(voltage="5.2V to 12.6V"))
 GND = io("GND", Ground)
 VREF = io("VREF", Power)
 

--- a/Reference_Voltage/REF3240AMDBVREP.zen
+++ b/Reference_Voltage/REF3240AMDBVREP.zen
@@ -31,9 +31,9 @@ rise_time = config("rise_time", RiseTime, default="10ms")  # Supply rise time fo
 use_force_sense = config("use_force_sense", bool, default=False)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("ENABLE", Net, default=Net("ENABLE")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("ENABLE", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets

--- a/Reference_Voltage/REF6050.zen
+++ b/Reference_Voltage/REF6050.zen
@@ -66,26 +66,26 @@ Capacitor(name="C_IN", value="100nF", package="0402", P1=VIN, P2=GND, dnp=not ad
 if add_output_cap:
     _ESR = Net("ESR") if esr != Esr("None") else VOUT
 
-    # ESR Capacitor - For applications requiring specific ESR for stability
-    if esr != Esr("None"):
-        # Section 9.3.4: Stability
-        # At a low output-capacitor value of 10 µF, an effective series resistance (ESR)
-        # of 20 mΩ to 100 mΩ is required for stability; whereas, at a higher value of
-        # 47 µF, an ESR of 5 mΩ to 100 mΩ is required.
+    # Per datasheet §9.3.4 (Stability): a 10µF cap needs ESR in [20mΩ, 100mΩ],
+    # while a 47µF cap needs ESR in [5mΩ, 100mΩ]. Pair the ESR resistor with
+    # the appropriate output capacitor value.
+    _esr_cap_table = {
+        Esr("5mohm"): ("5mohms 1%", "47uF"),
+        Esr("10mohm"): ("10mohms 1%", "47uF"),
+        Esr("20mohm"): ("20mohms 1%", "10uF"),
+        Esr("50mohm"): ("50mohms 1%", "10uF"),
+    }
 
-        esr_cap_table = {
-            Esr("5mohm"): "5mohms 1%",
-            Esr("10mohm"): "10mohms 1%",
-            Esr("20mohm"): "20mohms 1%",
-            Esr("50mohm"): "50mohms 1%",
-        }
-        _output_r = esr_cap_table.get(esr, "20mohm")
+    if esr != Esr("None"):
+        _output_r, _output_c = _esr_cap_table.get(esr, ("20mohms 1%", "10uF"))
 
         # ESR resistor in series with capacitor
         Resistor(name="R_ESR", value=_output_r, package="0402", P1=VOUT, P2=_ESR)
+    else:
+        _output_c = "47uF"
 
     # Primary output capacitor (ceramic with low ESR)
-    Capacitor(name="C_OUT", value="47uF", package="1206", P1=_ESR, P2=GND)
+    Capacitor(name="C_OUT", value=_output_c, package="1206", P1=_ESR, P2=GND)
 
 # Filter Capacitor - Required ≥1µF for stability
 Capacitor(name="C_FILT", value="1uF", package="0603", P1=_FILT, P2=GND, dnp=not add_filter_cap)

--- a/Reference_Voltage/REF6050.zen
+++ b/Reference_Voltage/REF6050.zen
@@ -33,9 +33,9 @@ esr = config("equivalent_esr", Esr, default="5mohm")
 current_limit = config("current_limit", CurrentLimit, default="13mA")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
@@ -65,7 +65,6 @@ Capacitor(name="C_IN", value="100nF", package="0402", P1=VIN, P2=GND, dnp=not ad
 # Output Capacitor - Datasheet specifies 10µF to 47µF for stability
 if add_output_cap:
     _ESR = Net("ESR") if esr != Esr("None") else VOUT
-    output_c = "47uF"
 
     # ESR Capacitor - For applications requiring specific ESR for stability
     if esr != Esr("None"):
@@ -75,15 +74,15 @@ if add_output_cap:
         # 47 µF, an ESR of 5 mΩ to 100 mΩ is required.
 
         esr_cap_table = {
-            Esr("5mohm"): ("5mohms 1%", "47uF"),
-            Esr("10mohm"): ("10mohms 1%", "47uF"),
-            Esr("20mohm"): ("20mohms 1%", "10uF"),
-            Esr("50mohm"): ("50mohms 1%", "10uF"),
+            Esr("5mohm"): "5mohms 1%",
+            Esr("10mohm"): "10mohms 1%",
+            Esr("20mohm"): "20mohms 1%",
+            Esr("50mohm"): "50mohms 1%",
         }
-        output_r, output_c = esr_cap_table.get(esr, ("20mohm", "10uF"))
+        _output_r = esr_cap_table.get(esr, "20mohm")
 
         # ESR resistor in series with capacitor
-        Resistor(name="R_ESR", value=output_r, package="0402", P1=VOUT, P2=_ESR)
+        Resistor(name="R_ESR", value=_output_r, package="0402", P1=VOUT, P2=_ESR)
 
     # Primary output capacitor (ceramic with low ESR)
     Capacitor(name="C_OUT", value="47uF", package="1206", P1=_ESR, P2=GND)

--- a/Regulator_Linear/ADP7142ARDZ-1.8.zen
+++ b/Regulator_Linear/ADP7142ARDZ-1.8.zen
@@ -12,7 +12,7 @@ Reviewer: @DiodeComputers/davide-asnaghi
 Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ADP7142.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -29,9 +29,9 @@ if add_soft_start:
     soft_start_time = config("soft_start_time", str, default="10ms")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets

--- a/Regulator_Linear/ADP7182AUJZ-5.0.zen
+++ b/Regulator_Linear/ADP7182AUJZ-5.0.zen
@@ -32,7 +32,7 @@ add_output_discharge = config("add_output_discharge", bool, default=True)
 # External IO
 VIN = io("VIN", Power)
 VOUT = io("VOUT", Power)
-EN = io("EN", Net, default=Net("EN")) if enable_control else VIN
+EN = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # -200mA, Low Noise, CMOS Low Dropout Regulator, Negative, -5.0V Fixed Output, TSOT-23-5
@@ -44,7 +44,6 @@ Component(
         "GND": GND,
         "VIN": VIN,
         "EN": EN,
-        "NC": NotConnected(),  # No connect pin
         "VOUT": VOUT,
     },
 )

--- a/Regulator_Linear/AMS1117CD-5.0.zen
+++ b/Regulator_Linear/AMS1117CD-5.0.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: http://www.advanced-monolithic.com/pdf/ds1117.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -24,8 +24,8 @@ add_output_cap = config("add_output_cap", bool, default=True)
 add_protection_diode = config("add_protection_diode", bool, default=False)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VI"))
-VOUT = io("VOUT", Net, default=Net("VO"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # 1A Low Dropout regulator, positive, 5.0V fixed output, TO-252

--- a/Regulator_Linear/AMS1117CD-ADJ.zen
+++ b/Regulator_Linear/AMS1117CD-ADJ.zen
@@ -12,7 +12,7 @@ Reviewer: @DiodeComputers/davide-asnaghi
 Datasheet: http://www.advanced-monolithic.com/pdf/ds1117.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
 
 # Dependencies
@@ -39,8 +39,8 @@ else:
     GND_PIN = "ADJ"
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Internal IO

--- a/Regulator_Linear/AMS1117CD.zen
+++ b/Regulator_Linear/AMS1117CD.zen
@@ -12,7 +12,7 @@ Reviewer: @DiodeComputers/davide-asnaghi
 Datasheet: http://www.advanced-monolithic.com/pdf/ds1117.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
 
 # Dependencies
@@ -39,8 +39,8 @@ else:
     GND_PIN = "ADJ"
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Internal IO

--- a/Regulator_Linear/AP130-35Y.zen
+++ b/Regulator_Linear/AP130-35Y.zen
@@ -65,8 +65,8 @@ add_power_good_led = config("add_power_good_led", bool, default=False, optional=
 add_test_points = config("add_test_points", bool, default=False, optional=True)
 
 # External IO
-VIN = io("VIN", Power, default=Power("VIN"), checks=voltage_within("2.7V to 5.5V"))
-VOUT = io("VOUT", Power, default=Power("VOUT"))
+VIN = io("VIN", Power, checks=voltage_within("2.7V to 5.5V"))
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Internal nets

--- a/Regulator_Linear/AP130-35Y.zen
+++ b/Regulator_Linear/AP130-35Y.zen
@@ -13,7 +13,6 @@ Datasheet: http://www.diodes.com/datasheets/AP130.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Inductance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -65,7 +64,7 @@ add_power_good_led = config("add_power_good_led", bool, default=False, optional=
 add_test_points = config("add_test_points", bool, default=False, optional=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.7V to 5.5V"))
+VIN = io("VIN", Power(voltage="2.7V to 5.5V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/AP2112K-3.3.zen
+++ b/Regulator_Linear/AP2112K-3.3.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.diodes.com/assets/Datasheets/AP2112.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Inductance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -73,7 +72,7 @@ add_power_good_led = config("add_power_good_led", bool, default=False, optional=
 add_test_points = config("add_test_points", bool, default=False, optional=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.5V to 6V"))
+VIN = io("VIN", Power(voltage="2.5V to 6V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/AP2112K-3.3.zen
+++ b/Regulator_Linear/AP2112K-3.3.zen
@@ -73,8 +73,8 @@ add_power_good_led = config("add_power_good_led", bool, default=False, optional=
 add_test_points = config("add_test_points", bool, default=False, optional=True)
 
 # External IO
-VIN = io("VIN", Power, default=Power("VIN"), checks=voltage_within("2.5V to 6V"))
-VOUT = io("VOUT", Power, default=Power("VOUT"))
+VIN = io("VIN", Power, checks=voltage_within("2.5V to 6V"))
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin handling based on configuration
@@ -85,7 +85,6 @@ if enable_control != EnableControl("AlwaysOn"):
 
 # Internal nets
 _VIN_FILT = Net("VIN_FILT") if input_filter_type != InputFilterType("None") else VIN
-_NC = NotConnected()  # No connect pin
 
 # Main regulator component
 Component(
@@ -96,7 +95,6 @@ Component(
         "VIN": _VIN_FILT,
         "EN": _VIN_FILT if enable_control == EnableControl("AlwaysOn") else _EN,
         "GND": GND,
-        "NC": _NC,
         "VOUT": VOUT,
     },
 )

--- a/Regulator_Linear/AP7361C-28E.zen
+++ b/Regulator_Linear/AP7361C-28E.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.diodes.com/assets/Datasheets/AP7361C.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,7 +32,7 @@ add_test_points = config("add_test_points", bool, default=True)
 passive_size = config("passive_size", PackageSize, default="0603")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.2V to 6V"))
+VIN = io("VIN", Power(voltage="2.2V to 6V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/AP7370-12FDC.zen
+++ b/Regulator_Linear/AP7370-12FDC.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.diodes.com/assets/Datasheets/AP7370.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,7 +32,7 @@ add_test_points = config("add_test_points", bool, default=True)
 passive_size = config("passive_size", PackageSize, default="0603")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("3.2V to 18V"))
+VIN = io("VIN", Power(voltage="3.2V to 18V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/AP7370-12FDC.zen
+++ b/Regulator_Linear/AP7370-12FDC.zen
@@ -44,7 +44,6 @@ Component(
     footprint=File("@kicad-footprints/Package_DFN_QFN.pretty/DFN-6-1EP_2x2mm_P0.65mm_EP1.01x1.7mm.kicad_mod"),
     pins={
         "VI": VIN,
-        "NC": GND,  # NC (Not connected)
         "GND": GND,
         "VO": VOUT,
     },

--- a/Regulator_Linear/AP7381-28SA-7.zen
+++ b/Regulator_Linear/AP7381-28SA-7.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.diodes.com/assets/Datasheets/AP7381.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,7 +32,7 @@ add_test_points = config("add_test_points", bool, default=True)
 passive_size = config("passive_size", PackageSize, default="0603")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("3.5V to 40V"))
+VIN = io("VIN", Power(voltage="3.5V to 40V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/AP7381-70SA-7.zen
+++ b/Regulator_Linear/AP7381-70SA-7.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.diodes.com/assets/Datasheets/AP7381.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,7 +32,7 @@ add_test_points = config("add_test_points", bool, default=True)
 passive_size = config("passive_size", PackageSize, default="0603")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("8V to 40V"))
+VIN = io("VIN", Power(voltage="8V to 40V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/APE8865NR-24-HF-3.zen
+++ b/Regulator_Linear/APE8865NR-24-HF-3.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.a-powerusa.com/docs/APE8865-3.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,7 +32,7 @@ add_test_points = config("add_test_points", bool, default=True)
 passive_size = config("passive_size", PackageSize, default="0603")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.8V to 5.5V"))
+VIN = io("VIN", Power(voltage="2.8V to 5.5V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/APE8865U5-32-HF-3.zen
+++ b/Regulator_Linear/APE8865U5-32-HF-3.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.apec-usa.com/datasheet/APE8865-3.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -35,7 +34,7 @@ passive_size = config("passive_size", PackageSize, default="0603")
 shutdown_config = config("shutdown_config", ShutdownConfig, default="PullUp")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("3.5V to 5.5V"))
+VIN = io("VIN", Power(voltage="3.5V to 5.5V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/APE8865Y5-27-HF-3.zen
+++ b/Regulator_Linear/APE8865Y5-27-HF-3.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.alldatasheet.com/datasheet-pdf/pdf/1131828/APEC/APE8865Y5
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -35,7 +34,7 @@ passive_size = config("passive_size", PackageSize, default="0603")
 shutdown_config = config("shutdown_config", ShutdownConfig, default="PullUp")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.8V to 5.5V"))
+VIN = io("VIN", Power(voltage="2.8V to 5.5V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/LM317_SOT-223.zen
+++ b/Regulator_Linear/LM317_SOT-223.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm317.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -60,7 +59,7 @@ add_protection_diodes = config("add_protection_diodes", bool, default=False)
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("1.25V to 37V"))
+VIN = io("VIN", Power(voltage="1.25V to 37V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/LM317_SOT-223.zen
+++ b/Regulator_Linear/LM317_SOT-223.zen
@@ -170,8 +170,8 @@ if add_input_cap:
         Capacitor(name="C_IN", value="10uF", voltage="50V", package=passives_size, P1=_VI, P2=GND)
     elif input_cap_type == InputCapacitorType("Electrolytic"):
         # Electrolytic for high current/ripple applications
-        cap_size = "1210" if passives_size == "0603" else "1206"
-        Capacitor(name="C_IN", value="10uF", voltage="50V", package=cap_size, P1=_VI, P2=GND)
+        _cin_size = "1210" if passives_size == "0603" else "1206"
+        Capacitor(name="C_IN", value="10uF", voltage="50V", package=_cin_size, P1=_VI, P2=GND)
     else:  # Both
         Capacitor(name="C_IN1", value="10uF", voltage="50V", package="1206", P1=_VI, P2=GND)
         Capacitor(name="C_IN2", value="100nF", voltage="50V", package=passives_size, P1=_VI, P2=GND)
@@ -182,17 +182,17 @@ if add_output_cap:
         Capacitor(name="C_OUT", value="1uF", voltage="50V", package=passives_size, P1=_VO, P2=GND)
     elif output_cap_type == OutputCapacitorType("Tantalum"):
         # Tantalum for better transient response
-        cap_size = "1210" if passives_size == "0603" else "1206"
-        Capacitor(name="C_OUT", value="1uF", voltage="35V", package=cap_size, P1=_VO, P2=GND)
+        _cout_size = "1210" if passives_size == "0603" else "1206"
+        Capacitor(name="C_OUT", value="1uF", voltage="35V", package=_cout_size, P1=_VO, P2=GND)
     elif output_cap_type == OutputCapacitorType("Electrolytic"):
-        cap_size = "1210" if passives_size == "0603" else "1206"
-        Capacitor(name="C_OUT", value="100uF", voltage="35V", package=cap_size, P1=_VO, P2=GND)
+        _cout_size = "1210" if passives_size == "0603" else "1206"
+        Capacitor(name="C_OUT", value="100uF", voltage="35V", package=_cout_size, P1=_VO, P2=GND)
 
 # Adjust pin capacitor for improved ripple rejection
 if add_adjust_cap:
     # Typically 10µF for 80dB ripple rejection at 120Hz
-    cap_size = "1206" if passives_size == "0603" else "0805"
-    Capacitor(name="C_ADJ", value=adjust_cap_value, voltage="25V", package=cap_size, P1=_ADJ, P2=GND)
+    _cadj_size = "1206" if passives_size == "0603" else "0805"
+    Capacitor(name="C_ADJ", value=adjust_cap_value, voltage="25V", package=_cadj_size, P1=_ADJ, P2=GND)
 
 # Protection diodes
 if add_protection_diodes:

--- a/Regulator_Linear/LM3480-12.zen
+++ b/Regulator_Linear/LM3480-12.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm3480.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance")
 
 # Dependencies
@@ -29,8 +29,8 @@ bulk_input_cap_value = config("bulk_input_cap_value", Capacitance, default="10uF
 
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # 100mA, Quasi Low Dropout Voltage Regulator, 12V positive fixed output, SOT-23 package

--- a/Regulator_Linear/LM3480-15.zen
+++ b/Regulator_Linear/LM3480-15.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm3480.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance")
 
 # Dependencies
@@ -29,8 +29,8 @@ bulk_input_cap_value = config("bulk_input_cap_value", Capacitance, default="10uF
 
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # 100mA, Quasi Low Dropout Voltage Regulator, 15V positive fixed output, SOT-23 package

--- a/Regulator_Linear/LT1962-3.zen
+++ b/Regulator_Linear/LT1962-3.zen
@@ -54,7 +54,6 @@ else:
 
 # Internal nets
 _BYP = Net("BYP")
-_NC = NotConnected()
 _SENSE = VOUT if enable_sense_connection else Net("SENSE")
 
 # Main LT1962-3 component
@@ -66,7 +65,6 @@ Component(
         "IN": VIN,
         "~{SHDN}": SHDN if enable_control else VIN,
         "GND": GND,
-        "NC": _NC,
         "OUT": VOUT,
         "SENSE": _SENSE,
         "BYP": _BYP,

--- a/Regulator_Linear/MAX38908.zen
+++ b/Regulator_Linear/MAX38908.zen
@@ -67,7 +67,7 @@ add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
 VIN = io("VIN", Power, checks=voltage_within("0.9V to 5.5V"))
-VBIAS = io("VBIAS", Net)
+VBIAS = io("VBIAS", Power)
 GND = io("GND", Ground)
 VOUT = io("VOUT", Power)
 

--- a/Regulator_Linear/MAX38908.zen
+++ b/Regulator_Linear/MAX38908.zen
@@ -27,7 +27,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -66,7 +65,7 @@ add_output_bulk_cap = config("add_output_bulk_cap", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("0.9V to 5.5V"))
+VIN = io("VIN", Power(voltage="0.9V to 5.5V"))
 VBIAS = io("VBIAS", Power)
 GND = io("GND", Ground)
 VOUT = io("VOUT", Power)

--- a/Regulator_Linear/MAX38909.zen
+++ b/Regulator_Linear/MAX38909.zen
@@ -67,7 +67,7 @@ add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
 VIN = io("VIN", Power, checks=voltage_within("0.9V to 5.5V"))
-VBIAS = io("VBIAS", Net)
+VBIAS = io("VBIAS", Power)
 GND = io("GND", Ground)
 VOUT = io("VOUT", Power)
 

--- a/Regulator_Linear/MAX38909.zen
+++ b/Regulator_Linear/MAX38909.zen
@@ -27,7 +27,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -66,7 +65,7 @@ add_output_bulk_cap = config("add_output_bulk_cap", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("0.9V to 5.5V"))
+VIN = io("VIN", Power(voltage="0.9V to 5.5V"))
 VBIAS = io("VBIAS", Power)
 GND = io("GND", Ground)
 VOUT = io("VOUT", Power)

--- a/Regulator_Linear/MCP1727-2502.zen
+++ b/Regulator_Linear/MCP1727-2502.zen
@@ -62,10 +62,9 @@ else:
     _PWRGD = Net("PWRGD_INT")
 
 # Internal nets
-_SENSE = Net("SENSE")
 _CDELAY = Net("CDELAY")
 
-# Connect SENSE to VOUT for fixed voltage operation (required for proper regulation)
+# SENSE is tied to VOUT for fixed-voltage operation (required for proper regulation).
 _SENSE = VOUT
 
 # 1.5A, Low Voltage, Low Quiescent Current LDO Regulator, 2.3-6V Input, Fixed 2.5V Output, 330mV Dropout, SOIC-8

--- a/Regulator_Linear/MCP1727-2502.zen
+++ b/Regulator_Linear/MCP1727-2502.zen
@@ -16,7 +16,6 @@ Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/20002200D.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -43,7 +42,7 @@ if add_power_good_delay:
     power_good_delay_cap = config("power_good_delay_cap", Capacitance, default="1000pF")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("2.3V to 6V"))
+VIN = io("VIN", Power(voltage="2.3V to 6V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/MCP1804.zen
+++ b/Regulator_Linear/MCP1804.zen
@@ -31,11 +31,8 @@ output_voltage = config("output_voltage", OutputVoltage, default="2.5")
 # External IO
 VIN = io("VIN", Power)
 VOUT = io("VOUT", Power)
-SHDN = io("SHDN", Net, default=Net("SHDN"))
+SHDN = io("SHDN", Net)
 GND = io("GND", Ground)
-
-# Internal nets
-_NC = NotConnected()
 
 # 150mA, 28V LDO Regulator With Shutdown, 2.5V Fixed Output, SOT-89-5
 Component(
@@ -46,7 +43,6 @@ Component(
         "VIN": VIN,
         "~{SHDN}": SHDN,
         "GND": GND,
-        "NC": _NC,
         "VOUT": VOUT,
     },
 )

--- a/Regulator_Linear/MCP1804.zen
+++ b/Regulator_Linear/MCP1804.zen
@@ -13,7 +13,7 @@ Reviewer: @DiodeComputers/davide-asnaghi
 Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/20002200D.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -29,8 +29,8 @@ add_shutdown_pullup = config("add_shutdown_pullup", bool, default=True)
 output_voltage = config("output_voltage", OutputVoltage, default="2.5")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 SHDN = io("SHDN", Net, default=Net("SHDN"))
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/MIC5317-3.3.zen
+++ b/Regulator_Linear/MIC5317-3.3.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/MIC5317-High-Performance-Single-150mA-LDO-DS20006195B.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -26,20 +26,19 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 150mA Low-dropout Voltage Regulator, Vout 3.3V, Vin up to 6V, SOT23-5
 Component(
     name="MIC5317_3V3",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="MIC5317-3.3xM5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"VIN": VIN, "EN": EN, "GND": GND, "NC": _NC, "VOUT": VOUT},
+    pins={"VIN": VIN, "EN": EN, "GND": GND, "VOUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/NCP1117-ADJ_SOT223.zen
+++ b/Regulator_Linear/NCP1117-ADJ_SOT223.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.onsemi.com/pdf/datasheet/ncp1117-d.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -43,7 +42,7 @@ add_protection_diodes = config("add_protection_diodes", ProtectionDiodes, defaul
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("1.25V to 18.8V"))
+VIN = io("VIN", Power(voltage="1.25V to 18.8V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Linear/TLV70030_SOT353.zen
+++ b/Regulator_Linear/TLV70030_SOT353.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv700.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -27,20 +27,19 @@ if enable_control:
     add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 200mA Low Dropout Voltage Regulator, Fixed Output 3V, SC70-5
 Component(
     name="TLV70030_SOT353",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV70030_SOT353"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-353_SC-70-5.kicad_mod"),
-    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TLV70032_SOT23-5.zen
+++ b/Regulator_Linear/TLV70032_SOT23-5.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv700.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -26,20 +26,19 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 200mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23-5
 Component(
     name="TLV70032_SOT23-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV70032_SOT23-5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TLV70033_SOT23-5.zen
+++ b/Regulator_Linear/TLV70033_SOT23-5.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv700.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -26,20 +26,17 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
-
-# Internal nets
-_NC = NotConnected()
 
 # 200mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
 Component(
     name="TLV70033_SOT23-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV70033_SOT23-5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TLV70036_SOT23-5.zen
+++ b/Regulator_Linear/TLV70036_SOT23-5.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv700.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -26,20 +26,19 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 200mA Low Dropout Voltage Regulator, Fixed Output 3.6V, SOT-23-5
 Component(
     name="TLV70036_SOT23-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV70036_SOT23-5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "GND": GND, "EN": EN_CTRL, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "GND": GND, "EN": EN_CTRL, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TLV70212_SOT23-5.zen
+++ b/Regulator_Linear/TLV70212_SOT23-5.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv702.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -26,20 +26,19 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
 Component(
     name="TLV70212_SOT23-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV70212_SOT23-5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TLV70228_SOT23-5.zen
+++ b/Regulator_Linear/TLV70228_SOT23-5.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv702.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -26,20 +26,19 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
 Component(
     name="TLV70228_SOT23-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV70228_SOT23-5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TLV71209_SOT23-5.zen
+++ b/Regulator_Linear/TLV71209_SOT23-5.zen
@@ -14,7 +14,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv712.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -28,20 +28,19 @@ if enable_control:
     add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 300mA Low Dropout Voltage Regulator, Fixed Output 0.9V, SOT-23-5
 Component(
     name="TLV71209_SOT23-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV71209_SOT23-5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TLV71211_SOT23-5.zen
+++ b/Regulator_Linear/TLV71211_SOT23-5.zen
@@ -14,7 +14,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tlv712.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -27,20 +27,19 @@ enable_control = config("enable_control", bool, default=True)
 add_enable_pullup = config("add_enable_pullup", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
-_NC = NotConnected()
 
 # 300mA Low Dropout Voltage Regulator, Fixed Output 1.1V, SOT-23-5
 Component(
     name="TLV71211_SOT23-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TLV71211_SOT23-5"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": EN_CTRL, "GND": GND, "OUT": VOUT},
 )
 
 # Input Capacitor - Datasheet recommends 1μF ceramic

--- a/Regulator_Linear/TPS7A0508PDBV.zen
+++ b/Regulator_Linear/TPS7A0508PDBV.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps7a05.pdf
 """
 
-load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
@@ -47,14 +47,14 @@ else:
     _EN = Net("EN")
 
 # Internal net for NC pin
-_NC = NotConnected()
+
 
 # 200mA Ultra-Low-Iq regulator, positive, 0.8V fixed output, SOT-23-5
 Component(
     name="TPS7A0508PDBV",
     symbol=Symbol(library="@kicad-symbols/Regulator_Linear.kicad_sym", name="TPS7A0508PDBV"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "EN": _EN, "GND": GND, "NC": _NC, "OUT": VOUT},
+    pins={"IN": VIN, "EN": _EN, "GND": GND, "OUT": VOUT},
 )
 
 # Enable pin configuration

--- a/Regulator_Linear/TPS7A0508PDBV.zen
+++ b/Regulator_Linear/TPS7A0508PDBV.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/tps7a05.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -35,7 +34,7 @@ passive_size = config("passive_size", PackageSize, default="0603")
 enable_config = config("enable_config", EnableConfig, default="PullUp")
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("1.4V to 5.5V"))
+VIN = io("VIN", Power(voltage="1.4V to 5.5V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_SwitchedCapacitor/LM2775DSG.zen
+++ b/Regulator_SwitchedCapacitor/LM2775DSG.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm2776.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -27,9 +27,9 @@ pfm_mode = config("pfm_mode", bool, default=True)
 output_discharge = config("output_discharge", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets

--- a/Regulator_SwitchedCapacitor/LTC1502.zen
+++ b/Regulator_SwitchedCapacitor/LTC1502.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/1502f.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,17 +33,22 @@ output_cap_value = config("output_cap_value", CapacitorValue, default="10uF")
 add_output_filter = config("add_output_filter", bool, default=False)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 if shutdown_control == ShutdownControl("External"):
-    SHDN = io("SHDN", Net, default=Net("SHDN"))
+    SHDN = io("SHDN", Net)
 elif shutdown_control == ShutdownControl("Mosfet"):
-    SHDN_CTRL = io("SHDN_CTRL", Net, default=Net("SHDN_CTRL"))
+    SHDN_CTRL = io("SHDN_CTRL", Net)
 
 # Internal nets
 _C1_PLUS = Net("C1+")
-_C1_MINUS_SHDN = Net("C1-/SHDN")
+# C1- and SHDN share a pin: in External mode it tracks SHDN directly; in
+# Mosfet/None mode it stays on an internal net that C1 hangs from.
+if shutdown_control == ShutdownControl("External"):
+    _C1_MINUS_SHDN = SHDN
+else:
+    _C1_MINUS_SHDN = Net("C1-/SHDN")
 _C2 = Net("C2")
 _C3_PLUS = Net("C3+")
 _C3_MINUS = Net("C3-")
@@ -84,14 +89,9 @@ Capacitor(name="C2_CAP", value="10uF", package="0805", P1=_C2, P2=GND)
 
 # Shutdown Control
 # None: SHDN pin is left floating (device always enabled)
-# External: Direct connection to external control signal
+# External: Direct connection to external control signal (handled above)
 # Mosfet: N-channel MOSFET control for MCU compatibility
-if shutdown_control == ShutdownControl("External"):
-    # Direct connection for external shutdown control
-    # External circuit must provide proper pull-down (<0.2V) and Hi-Z states
-    _C1_MINUS_SHDN = SHDN
-
-elif shutdown_control == ShutdownControl("Mosfet"):
+if shutdown_control == ShutdownControl("Mosfet"):
     # N-channel MOSFET shutdown control with 100Ω series resistor
     # MCU drives gate to pull SHDN pin low when MOSFET is on
 

--- a/Regulator_SwitchedCapacitor/TPS60400DBV.zen
+++ b/Regulator_SwitchedCapacitor/TPS60400DBV.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps60400.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -44,20 +44,22 @@ elif output_filter == FilterType("LC"):
     lc_cap_value = config("lc_cap_value", LCCapacitorValue, default="10uF")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Internal nets
 _CFLY_P = Net("C_FLY+")
 _CFLY_N = Net("C_FLY-")
+# Chip-side output net; output filter (if any) sits between _VOUT_CHIP and VOUT.
+_VOUT_CHIP = Power("VOUT_CHIP") if output_filter != FilterType("None") else VOUT
 
 # Unregulated 60-mA Charge Pump Voltage Inverter with Variable Switching Frequency 50 kHz - 250 kHz, SOT-23-5
 Component(
     name="TPS60400DBV",
     symbol=Symbol(library="@kicad-symbols/Regulator_SwitchedCapacitor.kicad_sym", name="TPS60400DBV"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "GND": GND, "OUT": VOUT, "C_{FLY+}": _CFLY_P, "C_{FLY-}": _CFLY_N},
+    pins={"IN": VIN, "GND": GND, "OUT": _VOUT_CHIP, "C_{FLY+}": _CFLY_P, "C_{FLY-}": _CFLY_N},
 )
 
 # Input Capacitor - Datasheet recommends same value as flying capacitor
@@ -66,33 +68,21 @@ Capacitor(name="C_IN", value=input_cap_value.value, package="0805", P1=VIN, P2=G
 # Flying Capacitor - Required for charge pump operation
 Capacitor(name="C_FLY", value=flying_cap_value.value, package="0805", P1=_CFLY_P, P2=_CFLY_N, dnp=not add_flying_cap)
 
-# Output Capacitor - Required for filtering and stability
-Capacitor(name="C_OUT", value=output_cap_value.value, package="0805", P1=VOUT, P2=GND, dnp=not add_output_cap)
+# Output Capacitor - Required for filtering and stability (on chip-side output node)
+Capacitor(name="C_OUT", value=output_cap_value.value, package="0805", P1=_VOUT_CHIP, P2=GND, dnp=not add_output_cap)
 
 # Optional Output Filter
 if output_filter == FilterType("RC"):
     # RC filter for additional ripple reduction
     Resistor = Module("@stdlib/generics/Resistor.zen")
-    _VOUT_FILT = Net("VOUT_FILTERED")
-
-    # Typical values for RC filter
-    Resistor(name="R_FILT", value=rc_res_value.value, package="0603", P1=VOUT, P2=_VOUT_FILT)
-    Capacitor(name="C_FILT", value=rc_cap_value.value, package="0603", P1=_VOUT_FILT, P2=GND)
-
-    # Update output to filtered net
-    VOUT = _VOUT_FILT
+    Resistor(name="R_FILT", value=rc_res_value.value, package="0603", P1=_VOUT_CHIP, P2=VOUT)
+    Capacitor(name="C_FILT", value=rc_cap_value.value, package="0603", P1=VOUT, P2=GND)
 
 elif output_filter == FilterType("LC"):
     # LC filter for maximum ripple reduction
     Inductor = Module("@stdlib/generics/Inductor.zen")
-    _VOUT_FILT = Net("VOUT_FILTERED")
-
-    # Typical values for LC filter
-    Inductor(name="L_FILT", value=lc_ind_value.value, package="1210", P1=VOUT, P2=_VOUT_FILT)
-    Capacitor(name="C_FILT", value=lc_cap_value.value, package="0805", P1=_VOUT_FILT, P2=GND)
-
-    # Update output to filtered net
-    VOUT = _VOUT_FILT
+    Inductor(name="L_FILT", value=lc_ind_value.value, package="1210", P1=_VOUT_CHIP, P2=VOUT)
+    Capacitor(name="C_FILT", value=lc_cap_value.value, package="0805", P1=VOUT, P2=GND)
 
 # pcb:sch TPS60400DBV x=-26.4000 y=-13.7000 rot=0
 # pcb:sch C_IN.C x=-97.5200 y=49.8000 rot=0

--- a/Regulator_SwitchedCapacitor/TPS60403DBV.zen
+++ b/Regulator_SwitchedCapacitor/TPS60403DBV.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps60403.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -43,20 +43,21 @@ elif output_filter == FilterType("LC"):
     lc_cap_value = config("lc_cap_value", LCCapacitorValue, default="10uF")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Internal nets
 _CFLY_P = Net("C_FLY+")
 _CFLY_N = Net("C_FLY-")
+_VOUT_CHIP = Power("VOUT_CHIP") if output_filter != FilterType("None") else VOUT
 
 # Unregulated 60-mA Charge Pump Voltage Inverter with Fixed Switching Frequency 250 kHz, SOT-23-5
 Component(
     name="TPS60403DBV",
     symbol=Symbol(library="@kicad-symbols/Regulator_SwitchedCapacitor.kicad_sym", name="TPS60403DBV"),
     footprint=File("@kicad-footprints/Package_TO_SOT_SMD.pretty/SOT-23-5.kicad_mod"),
-    pins={"IN": VIN, "GND": GND, "OUT": VOUT, "C_{FLY+}": _CFLY_P, "C_{FLY-}": _CFLY_N},
+    pins={"IN": VIN, "GND": GND, "OUT": _VOUT_CHIP, "C_{FLY+}": _CFLY_P, "C_{FLY-}": _CFLY_N},
 )
 
 # Input Capacitor - Datasheet recommends same value as flying capacitor
@@ -66,32 +67,20 @@ Capacitor(name="C_IN", value=input_cap_value.value, package="0805", P1=VIN, P2=G
 Capacitor(name="C_FLY", value=flying_cap_value.value, package="0805", P1=_CFLY_P, P2=_CFLY_N, dnp=not add_flying_cap)
 
 # Output Capacitor - Required for filtering and stability
-Capacitor(name="C_OUT", value=output_cap_value.value, package="0805", P1=VOUT, P2=GND, dnp=not add_output_cap)
+Capacitor(name="C_OUT", value=output_cap_value.value, package="0805", P1=_VOUT_CHIP, P2=GND, dnp=not add_output_cap)
 
 # Optional Output Filter
 if output_filter == FilterType("RC"):
     # RC filter for additional ripple reduction
     Resistor = Module("@stdlib/generics/Resistor.zen")
-    _VOUT_FILT = Net("VOUT_FILTERED")
-
-    # Typical values for RC filter
-    Resistor(name="R_FILT", value=rc_res_value.value, package="0603", P1=VOUT, P2=_VOUT_FILT)
-    Capacitor(name="C_FILT", value=rc_cap_value.value, package="0603", P1=_VOUT_FILT, P2=GND)
-
-    # Update output to filtered net
-    VOUT = _VOUT_FILT
+    Resistor(name="R_FILT", value=rc_res_value.value, package="0603", P1=_VOUT_CHIP, P2=VOUT)
+    Capacitor(name="C_FILT", value=rc_cap_value.value, package="0603", P1=VOUT, P2=GND)
 
 elif output_filter == FilterType("LC"):
     # LC filter for maximum ripple reduction
     Inductor = Module("@stdlib/generics/Inductor.zen")
-    _VOUT_FILT = Net("VOUT_FILTERED")
-
-    # Typical values for LC filter
-    Inductor(name="L_FILT", value=lc_ind_value.value, package="1210", P1=VOUT, P2=_VOUT_FILT)
-    Capacitor(name="C_FILT", value=lc_cap_value.value, package="0805", P1=_VOUT_FILT, P2=GND)
-
-    # Update output to filtered net
-    VOUT = _VOUT_FILT
+    Inductor(name="L_FILT", value=lc_ind_value.value, package="1210", P1=_VOUT_CHIP, P2=VOUT)
+    Capacitor(name="C_FILT", value=lc_cap_value.value, package="0805", P1=VOUT, P2=GND)
 
 # pcb:sch TPS60403DBV x=-26.4000 y=-13.7000 rot=0
 # pcb:sch C_IN.C x=-97.5200 y=49.8000 rot=0

--- a/Regulator_Switching/LM2576HVS-12.zen
+++ b/Regulator_Switching/LM2576HVS-12.zen
@@ -14,7 +14,7 @@ Reviewer: @DiodeComputers/davide-asnaghi
 Datasheet: https://www.ti.com/lit/ds/symlink/lm2576.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -34,9 +34,9 @@ enable_control = config("enable_control", bool, default=True)
 inductor_value = config("inductor_value", InductorValue, default="100uH")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-ON_OFF = io("ON_OFF", Net, default=Net("ON/OFF")) if enable_control else GND
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+ON_OFF = io("ON_OFF", Net) if enable_control else GND
 GND = io("GND", Ground)
 
 # Internal nets

--- a/Regulator_Switching/LM2672M-12.zen
+++ b/Regulator_Switching/LM2672M-12.zen
@@ -73,7 +73,7 @@ _SS = Net("SS")  # Soft-start
 
 # Set up internal VIN net (will be connected through fuse if protection is enabled)
 if add_input_protection:
-    _VIN_INT = Net("VIN_FUSED")  # Internal VIN after fuse
+    _VIN_INT = Power("VIN_FUSED")  # Internal VIN after fuse
 else:
     _VIN_INT = VIN  # Direct connection when no protection
 

--- a/Regulator_Switching/LM2672M-12.zen
+++ b/Regulator_Switching/LM2672M-12.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm2672.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -48,7 +47,7 @@ optimize_for_size = config("optimize_for_size", bool, default=False)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("15V to 40V"))
+VIN = io("VIN", Power(voltage="15V to 40V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Switching/LM2672N-12.zen
+++ b/Regulator_Switching/LM2672N-12.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm2672.pdf
 """
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -49,7 +48,7 @@ optimize_for_size = config("optimize_for_size", bool, default=False)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VIN = io("VIN", Power, checks=voltage_within("15V to 40V"))
+VIN = io("VIN", Power(voltage="15V to 40V"))
 VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 

--- a/Regulator_Switching/LM2672N-12.zen
+++ b/Regulator_Switching/LM2672N-12.zen
@@ -74,7 +74,7 @@ _SS = Net("SS")  # Soft-start
 
 # Set up internal VIN net (will be connected through fuse if protection is enabled)
 if add_input_protection:
-    _VIN_INT = Net("VIN_FUSED")  # Internal VIN after fuse
+    _VIN_INT = Power("VIN_FUSED")  # Internal VIN after fuse
 else:
     _VIN_INT = VIN  # Direct connection when no protection
 

--- a/Regulator_Switching/LM2674N-12.zen
+++ b/Regulator_Switching/LM2674N-12.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm2674.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,23 +33,22 @@ enable_control = config("enable_control", bool, default=True)
 inductor_value = config("inductor_value", InductorValue, default="100uH")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-ON_OFF = io("ON_OFF", Net, default=Net("ON/OFF")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+ON_OFF = io("ON_OFF", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
 _VSW = Net("VSW")
 _CB = Net("CB")
 _FB = VOUT  # For fixed voltage version, FB connects directly to output
-_NC = NotConnected()
 
 # 12V, 500mA Step-Down Voltage Regulator, DIP-8
 Component(
     name="LM2674N-12",
     symbol=Symbol(library="@kicad-symbols/Regulator_Switching.kicad_sym", name="LM2674N-12"),
     footprint=File("@kicad-footprints/Package_DIP.pretty/DIP-8_W7.62mm.kicad_mod"),
-    pins={"VIN": VIN, "ON/~{OFF}": ON_OFF, "NC": _NC, "GND": GND, "FB": _FB, "CB": _CB, "VSW": _VSW},
+    pins={"VIN": VIN, "ON/~{OFF}": ON_OFF, "GND": GND, "FB": _FB, "CB": _CB, "VSW": _VSW},
 )
 
 # Boost Capacitor - Required for high-side driver

--- a/Regulator_Switching/LM2675N-5.zen
+++ b/Regulator_Switching/LM2675N-5.zen
@@ -12,7 +12,7 @@ Reviewer: <not_reviewed>
 Datasheet: https://www.ti.com/lit/ds/symlink/lm2576.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -33,23 +33,22 @@ enable_control = config("enable_control", bool, default=True)
 inductor_value = config("inductor_value", InductorValue, default="68uH")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-ON_OFF = io("ON_OFF", Net, default=Net("ON/OFF")) if enable_control else VIN
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+ON_OFF = io("ON_OFF", Net) if enable_control else VIN
 GND = io("GND", Ground)
 
 # Internal nets
 _VSW = Net("VSW")
 _CB = Net("CB")
 _FB = VOUT  # For fixed voltage version, FB connects directly to output
-_NC = NotConnected()
 
 # 5V, 1A Step-Down Voltage Regulator, DIP-8
 Component(
     name="LM2675N-5",
     symbol=Symbol(library="@kicad-symbols/Regulator_Switching.kicad_sym", name="LM2675N-5"),
     footprint=File("@kicad-footprints/Package_DIP.pretty/DIP-8_W7.62mm.kicad_mod"),
-    pins={"VIN": VIN, "ON/~{OFF}": ON_OFF, "NC": _NC, "GND": GND, "FB": _FB, "CB": _CB, "VSW": _VSW},
+    pins={"VIN": VIN, "ON/~{OFF}": ON_OFF, "GND": GND, "FB": _FB, "CB": _CB, "VSW": _VSW},
 )
 
 # Boost Capacitor - Required for high-side driver

--- a/Regulator_Switching/MIC2178-3.3.zen
+++ b/Regulator_Switching/MIC2178-3.3.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/mic2178.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -37,19 +37,25 @@ inductor_value = config("inductor_value", InductorValue, default="50uH")
 add_sync_pulldown = config("add_sync_pulldown", bool, default=True)
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
-EN_CTRL = io("EN", Net, default=Net("EN")) if enable_control else VIN
-SYNC_IN = io("SYNC", Net, default=Net("SYNC"))
-PWM_STATUS = io("PWM", Net, default=Net("PWM"))
-PWRGD = io("PWRGD", Net, default=Net("PWRGD"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
+EN_CTRL = io("EN", Net) if enable_control else VIN
+SYNC_IN = io("SYNC", Net)
+PWRGD = io("PWRGD", Net)
 GND = io("GND", Ground)
 
+# PWM status io is only meaningful outside `PWMOnly` mode; in PWMOnly the PWM
+# pin is tied to GND internally.
+if operation_mode != OperationMode("PWMOnly"):
+    PWM_STATUS = io("PWM", Net)
+    _PWM = PWM_STATUS
+else:
+    _PWM = GND
+
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _COMP = Net("COMP")
 _BIAS = Net("BIAS")
-_PWM = GND if operation_mode == OperationMode("PWMOnly") else PWM_STATUS
 _FB = VOUT  # For fixed 3.3V version, FB connects directly to output
 
 # 2.5A Synchronous Buck Regulator, 4.5-16.5V Input Voltage, 3.3V Fixed Output Voltage, SO-20W

--- a/Regulator_Switching/NBM7100A.zen
+++ b/Regulator_Switching/NBM7100A.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.nexperia.com/products/power-management/battery-life-boosters/NBM7100A.html
 """
 
-load("@stdlib/interfaces.zen", "I2c", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -39,13 +39,13 @@ storage_capacitance = config("storage_capacitance", StorageCapacitance, default=
 i2c_address = config("i2c_address", I2cAddress, default="0x2E")
 
 # External IO
-i2c = io("I2C", I2c, default=I2c("I2C"))
-VBT = io("VBT", Net, default=Net("VBT"))
-VDH = io("VDH", Net, default=Net("VDH"))
-VDP = io("VDP", Net, default=Net("VDP"))
-RDY = io("RDY", Net, default=Net("RDY"))
-START = io("START", Net, default=Net("START"))
-ADR = io("ADR", Net, default=Net("ADR"))
+i2c = io("I2C", I2c)
+VBT = io("VBT", Power)
+VDH = io("VDH", Power)
+VDP = io("VDP", Power)
+RDY = io("RDY", Net)
+START = io("START", Net)
+ADR = io("ADR", Net)
 GND = io("GND", Ground)
 
 # Internal nets
@@ -73,7 +73,6 @@ Component(
         "EP": GND,  # Exposed pad to ground
         "VSS": GND,
         "VSSP": GND,
-        "NC": NotConnected(),  # Not internally connected
         "VDHS": _VDHS,
         "VDH": VDH,
         "VDP": VDP,

--- a/Regulator_Switching/TPS562200.zen
+++ b/Regulator_Switching/TPS562200.zen
@@ -11,7 +11,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps562200.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -35,27 +35,23 @@ input_cap_config = config("input_cap_config", InputCapConfig, default="Enhanced"
 enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.76V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 2A Synchronous Step-Down Voltage Regulator
@@ -91,13 +87,10 @@ elif output_voltage == OutputVoltage("6.5V"):
 else:  # 7.0V
     r_top = "82.5kohms"
 
-# Feedback resistors (1% tolerance recommended)
+# Feedback resistors (1% tolerance recommended); skipped for 0.76V (direct connection).
 if output_voltage != OutputVoltage("0.76V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value="10kohms", package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.76V output
-    _VFB = VOUT
 
 # Bootstrap capacitor (required)
 Capacitor(name="C_BST", value=bootstrap_cap.value, voltage="10V", package="0402", P1=_VBST, P2=_SW)

--- a/Regulator_Switching/TPS562202.zen
+++ b/Regulator_Switching/TPS562202.zen
@@ -11,7 +11,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps562202.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -37,27 +37,23 @@ input_cap_config = config("input_cap_config", InputCapConfig, default="Enhanced"
 enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.804V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 2A Synchronous Step-Down Voltage Regulator
@@ -101,9 +97,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.804V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value="10kohms", package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.804V output
-    _VFB = VOUT
 
 # Bootstrap capacitor (required)
 Capacitor(name="C_BST", value=bootstrap_cap.value, voltage="10V", package="0402", P1=_VBST, P2=_SW)

--- a/Regulator_Switching/TPS562202S.zen
+++ b/Regulator_Switching/TPS562202S.zen
@@ -11,7 +11,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps562202s.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -37,27 +37,23 @@ input_cap_config = config("input_cap_config", InputCapConfig, default="Enhanced"
 enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.804V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 2A Synchronous Step-Down Voltage Regulator
@@ -101,9 +97,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.804V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value="10kohms", package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.804V output
-    _VFB = VOUT
 
 # Bootstrap capacitor (required)
 Capacitor(name="C_BST", value=bootstrap_cap.value, voltage="10V", package="0402", P1=_VBST, P2=_SW)

--- a/Regulator_Switching/TPS562203.zen
+++ b/Regulator_Switching/TPS562203.zen
@@ -11,7 +11,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps562203.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -35,27 +35,23 @@ input_cap_config = config("input_cap_config", InputCapConfig, default="Enhanced"
 enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.6V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 2A Synchronous Step-Down Voltage Regulator
@@ -94,9 +90,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.6V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value="30kohms", package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.6V output
-    _VFB = VOUT
 
 # Bootstrap capacitor (required)
 Capacitor(name="C_BST", value=bootstrap_cap.value, voltage="10V", package="0402", P1=_VBST, P2=_SW)

--- a/Regulator_Switching/TPS562206.zen
+++ b/Regulator_Switching/TPS562206.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps562206.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -36,27 +36,23 @@ input_cap_config = config("input_cap_config", InputCapConfig, default="Enhanced"
 enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.6V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 2A Synchronous Step-Down Voltage Regulator with FCCM
@@ -104,9 +100,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.6V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value=r_bot, package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.6V output
-    _VFB = VOUT
 
 # Bootstrap capacitor (required)
 Capacitor(name="C_BST", value=bootstrap_cap.value, voltage="10V", package="0402", P1=_VBST, P2=_SW)

--- a/Regulator_Switching/TPS563200.zen
+++ b/Regulator_Switching/TPS563200.zen
@@ -11,7 +11,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps563200.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -37,27 +37,23 @@ enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 feedforward_cap = config("feedforward_cap", FeedforwardCapValue, default="100pF")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.76V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 3A Synchronous Step-Down Voltage Regulator
@@ -96,9 +92,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.76V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value="10kohms", package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.76V output
-    _VFB = VOUT
 
 # Optional feedforward capacitor for improved transient response
 if feedforward_cap != FeedforwardCapValue("None") and output_voltage != OutputVoltage("0.76V"):

--- a/Regulator_Switching/TPS563202S.zen
+++ b/Regulator_Switching/TPS563202S.zen
@@ -11,7 +11,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps563202s.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -39,27 +39,23 @@ enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 feedforward_cap = config("feedforward_cap", FeedforwardCapValue, default="100pF")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.806V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 3A Synchronous Step-Down Voltage Regulator
@@ -102,9 +98,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.806V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value="10.0kohms", package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.806V output
-    _VFB = VOUT
 
 # Optional feedforward capacitor for improved transient response (recommended for Vout >= 2.5V)
 if feedforward_cap != FeedforwardCapValue("None") and output_voltage != OutputVoltage("0.806V"):

--- a/Regulator_Switching/TPS563203.zen
+++ b/Regulator_Switching/TPS563203.zen
@@ -11,7 +11,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps563203.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -37,27 +37,23 @@ enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 feedforward_cap = config("feedforward_cap", FeedforwardCapValue, default="18pF")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.6V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 3A Synchronous Step-Down Voltage Regulator
@@ -106,9 +102,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.6V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value=r_bot, package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.6V output
-    _VFB = VOUT
 
 # Optional feedforward capacitor for improved transient response (recommended for Vout >= 2.5V)
 if feedforward_cap != FeedforwardCapValue("None") and output_voltage != OutputVoltage("0.6V"):

--- a/Regulator_Switching/TPS563206.zen
+++ b/Regulator_Switching/TPS563206.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/tps563206.pdf
 """
 
-load("@stdlib/interfaces.zen", "Ground")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 
 # Dependencies
 Capacitor = Module("@stdlib/generics/Capacitor.zen")
@@ -38,27 +38,23 @@ enable_config = config("enable_config", EnableConfig, default="AlwaysOn")
 feedforward_cap = config("feedforward_cap", FeedforwardCapValue, default="18pF")
 
 # External IO
-VIN = io("VIN", Net, default=Net("VIN"))
-VOUT = io("VOUT", Net, default=Net("VOUT"))
+VIN = io("VIN", Power)
+VOUT = io("VOUT", Power)
 GND = io("GND", Ground)
 
 # Enable pin configuration
-if enable_config == EnableConfig("External"):
-    EN = io("EN", Net, default=Net("EN"))
-else:
-    EN = Net("EN")
+if enable_config == EnableConfig("External") or enable_config == EnableConfig("Pullup"):
+    EN = io("EN", Net)
+else:  # AlwaysOn: EN tracks VIN internally
+    EN = VIN
 
 # Internal nets
-_SW = Net("SW")
+_SW = Power("SW")
 _VBST = Net("VBST")
-_VFB = Net("VFB")
+_VFB = VOUT if output_voltage == OutputVoltage("0.6V") else Net("VFB")
 
-# Enable pin configuration
-if enable_config == EnableConfig("AlwaysOn"):
-    # Direct connection to VIN for always-on operation
-    EN = VIN
-elif enable_config == EnableConfig("Pullup"):
-    # Pull-up resistor to VIN with external control capability
+# EN pull-up when `Pullup` mode is selected
+if enable_config == EnableConfig("Pullup"):
     Resistor(name="R_EN", value="100kohms", package="0402", P1=EN, P2=VIN)
 
 # Main component - 3A Synchronous Step-Down Voltage Regulator in FCCM mode
@@ -107,9 +103,6 @@ else:  # 7.0V
 if output_voltage != OutputVoltage("0.6V"):
     Resistor(name="R_TOP", value=r_top, package="0402", P1=VOUT, P2=_VFB)
     Resistor(name="R_BOT", value=r_bot, package="0402", P1=_VFB, P2=GND)
-else:
-    # Direct connection for 0.6V output
-    _VFB = VOUT
 
 # Optional feedforward capacitor for improved transient response (recommended for Vout >= 2.5V)
 if feedforward_cap != FeedforwardCapValue("None") and output_voltage != OutputVoltage("0.6V"):

--- a/Sensor/BME280.zen
+++ b/Sensor/BME280.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datash
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Spi", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -46,12 +45,12 @@ add_power_decoupling = config("add_power_decoupling", bool, default=True)
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.71V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.71V to 3.6V"))
 GND = io("GND", Ground)
 
 # VDDIO - can be same as VDD or separate
 if add_vddio_separation:
-    VDDIO = io("VDDIO", Power, checks=voltage_within("1.71V to 3.6V"))
+    VDDIO = io("VDDIO", Power(voltage="1.71V to 3.6V"))
 else:
     VDDIO = VDD
 

--- a/Sensor/BME680.zen
+++ b/Sensor/BME680.zen
@@ -22,7 +22,6 @@ Datasheet: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datash
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Spi", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -45,12 +44,12 @@ add_power_decoupling = config("add_power_decoupling", bool, default=True)
 add_test_points = config("add_test_points", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.71V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.71V to 3.6V"))
 GND = io("GND", Ground)
 
 # VDDIO - can be same as VDD or separate
 if add_vddio_separation:
-    VDDIO = io("VDDIO", Power, checks=voltage_within("1.71V to 3.6V"))
+    VDDIO = io("VDDIO", Power(voltage="1.71V to 3.6V"))
 else:
     VDDIO = VDD
 

--- a/Sensor/INA260.zen
+++ b/Sensor/INA260.zen
@@ -17,7 +17,6 @@ Datasheet: https://www.ti.com/lit/ds/sbos893c/sbos893c.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -95,7 +94,7 @@ address_map = {
 a1_conn, a0_conn = address_map[i2c_address]
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("2.7V to 5.5V"))  # Power supply (2.7-5.5V)
+VS = io("VS", Power(voltage="2.7V to 5.5V"))  # Power supply (2.7-5.5V)
 GND = io("GND", Ground)
 i2c = io("I2C", I2c)  # I2C communication interface
 

--- a/Sensor/INA260.zen
+++ b/Sensor/INA260.zen
@@ -151,7 +151,6 @@ Component(
         "VBUS": _VBUS_FILT,
         "VS": VS,
         "GND": GND,
-        "NC": NotConnected(),  # No connect
         "ALERT": ALERT,
         "SCL": i2c.SCL,
         "SDA": i2c.SDA,

--- a/Sensor/LTC2990.zen
+++ b/Sensor/LTC2990.zen
@@ -139,17 +139,17 @@ diff_v3v4_enabled = measurement_mode in [
 # External IO
 VCC = io("VCC", Power)
 GND = io("GND", Ground)
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 
 # Measurement inputs - only expose those that are used
 if v1_enabled:
-    V1 = io("V1", Net, default=Net("V1"))
+    V1 = io("V1", Net)
 if v2_enabled:
-    V2 = io("V2", Net, default=Net("V2"))
+    V2 = io("V2", Net)
 if v3_enabled:
-    V3 = io("V3", Net, default=Net("V3"))
+    V3 = io("V3", Net)
 if v4_enabled:
-    V4 = io("V4", Net, default=Net("V4"))
+    V4 = io("V4", Net)
 
 # Address Configuration - Directly connect to GND/VCC based on selected address
 # ADR1 | ADR0 | Address

--- a/Sensor/MAX30102.zen
+++ b/Sensor/MAX30102.zen
@@ -80,10 +80,10 @@ else:
     _INT = Net("INT")
 
 # Internal nets
-PGND = Net("PGND")
+# PGND is a power-ground node, optionally filtered from main GND via a ferrite bead.
+PGND = Power("PGND") if add_led_power_filtering else GND
 
 # Create NC (No Connect) net for unused pins
-NC_NET = NotConnected()
 
 # Heart Rate Sensor, 14-OLGA
 Component(
@@ -93,7 +93,6 @@ Component(
     pins={
         "SCL": i2c.SCL,  # Pin 2
         "SDA": i2c.SDA,  # Pin 3
-        "NC": NC_NET,  # Multiple NC pins
         "VDD": VDD,  # Pin 11
         "PGND": PGND,  # Pin 4
         "VLED+": _VLED_PLUS,  # Pins 9 & 10 (connected internally)
@@ -106,9 +105,6 @@ Component(
 # Using a ferrite bead for noise isolation
 if add_led_power_filtering:
     FerriteBead(name="FB_PGND", package="0603", P1=GND, P2=PGND)
-else:
-    # Direct connection if no filtering
-    PGND = GND
 
 # Power Supply Decoupling
 if add_power_decoupling:

--- a/Sensor_Distance/VL53L0CXV0DH1.zen
+++ b/Sensor_Distance/VL53L0CXV0DH1.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/vl53l0x.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -52,7 +51,7 @@ if interrupt_config == InterruptConfig("Pullup"):
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.6V to 3.5V"))
+VDD = io("VDD", Power(voltage="2.6V to 3.5V"))
 GND = io("GND", Ground)
 I2C = io("I2C", I2c)
 

--- a/Sensor_Distance/VL53L0CXV0DH1.zen
+++ b/Sensor_Distance/VL53L0CXV0DH1.zen
@@ -54,7 +54,7 @@ add_test_points = config("add_test_points", bool, default=False)
 # External IO
 VDD = io("VDD", Power, checks=voltage_within("2.6V to 3.5V"))
 GND = io("GND", Ground)
-I2C = io("I2C", I2c, default=I2c())
+I2C = io("I2C", I2c)
 
 # Optional IOs based on configuration
 if shutdown_control == ShutdownControl("HostControlled"):
@@ -68,7 +68,6 @@ else:
     _GPIO1 = Net("GPIO1")
 
 # Internal nets
-_DNC = Net("DNC")  # Do Not Connect
 
 # Main component
 Component(
@@ -84,7 +83,6 @@ Component(
         "SCL": I2C.SCL,
         "XSHUT": _XSHUT if shutdown_control != ShutdownControl("HostControlled") else XSHUT,
         "GPIO1": _GPIO1 if interrupt_config == InterruptConfig("None") else GPIO1,
-        "DNC": _DNC,
     },
 )
 

--- a/Sensor_Distance/VL53L1CXV0FY1.zen
+++ b/Sensor_Distance/VL53L1CXV0FY1.zen
@@ -71,7 +71,6 @@ if reset_mode != ResetMode("None"):
 _AVDD = VDD
 _AVDDVCSEL = VDD
 _AVSSVCSEL = GND
-_DNC = Net("DNC")  # Do not connect
 
 # Internal nets for GPIO1 and XSHUT when not exposed
 _GPIO1 = GPIO1 if interrupt_mode != InterruptMode("None") else Net("GPIO1")
@@ -88,7 +87,6 @@ Component(
         "GND": GND,
         "XSHUT": _XSHUT,
         "GPIO1": _GPIO1,
-        "DNC": _DNC,
         "SDA": i2c.SDA,
         "SCL": i2c.SCL,
         "AVDD": _AVDD,
@@ -129,7 +127,6 @@ if add_i2c_pullups:
     Resistor(name="R_SCL", value=i2c_pullup_value, package=passives_size, P1=i2c.SCL, P2=VDD)
 
 # DNC (Do Not Connect) pin - must be left floating
-# No connection needed - the _DNC net remains unconnected
 
 # Test points for debugging (optional)
 add_test_points = config("add_test_points", bool, default=False, optional=True)

--- a/Sensor_Distance/VL53L1CXV0FY1.zen
+++ b/Sensor_Distance/VL53L1CXV0FY1.zen
@@ -17,7 +17,6 @@ Datasheet: https://www.espressif.com/sites/default/files/documentation/vl53l1x_d
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -50,7 +49,7 @@ if add_i2c_pullups:
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.6V to 3.5V"))
+VDD = io("VDD", Power(voltage="2.6V to 3.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Energy/INA219A.zen
+++ b/Sensor_Energy/INA219A.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina219.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -110,7 +109,7 @@ if add_input_filtering:
     input_filter_c = config("input_filter_c", Capacitance, default="100nF")
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("3V to 5.5V"))  # Power supply (3-5.5V)
+VS = io("VS", Power(voltage="3V to 5.5V"))  # Power supply (3-5.5V)
 GND = io("GND", Ground)
 i2c = io("I2C", I2c)  # I2C communication interface
 

--- a/Sensor_Energy/INA226.zen
+++ b/Sensor_Energy/INA226.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina226.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -98,7 +97,7 @@ if add_bus_resistor:
     bus_series_resistor = config("bus_series_resistor", Resistance, default="10ohms")
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("2.7V to 5.5V"))  # Power supply (2.7-5.5V)
+VS = io("VS", Power(voltage="2.7V to 5.5V"))  # Power supply (2.7-5.5V)
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Energy/INA228.zen
+++ b/Sensor_Energy/INA228.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina228.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -97,7 +96,7 @@ if add_bus_resistor:
     bus_series_resistor = config("bus_series_resistor", Resistance, default="10ohms")
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("2.7V to 5.5V"))  # Power supply (2.7-5.5V)
+VS = io("VS", Power(voltage="2.7V to 5.5V"))  # Power supply (2.7-5.5V)
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Energy/INA233.zen
+++ b/Sensor_Energy/INA233.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina233.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -97,7 +96,7 @@ if add_bus_resistor:
     bus_series_resistor = config("bus_series_resistor", Resistance, default="10ohms")
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("2.7V to 5.5V"))  # Power supply (2.7-5.5V)
+VS = io("VS", Power(voltage="2.7V to 5.5V"))  # Power supply (2.7-5.5V)
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Energy/INA237.zen
+++ b/Sensor_Energy/INA237.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina237.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -97,7 +96,7 @@ if add_bus_resistor:
     bus_series_resistor = config("bus_series_resistor", Resistance, default="10ohms")
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("2.7V to 5.5V"))  # Power supply (2.7-5.5V)
+VS = io("VS", Power(voltage="2.7V to 5.5V"))  # Power supply (2.7-5.5V)
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Energy/INA238.zen
+++ b/Sensor_Energy/INA238.zen
@@ -16,7 +16,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/ina238.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Capacitance", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -99,7 +98,7 @@ if add_bus_resistor:
     bus_series_resistor = config("bus_series_resistor", Resistance, default="10ohms")
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("2.7V to 5.5V"))  # Power supply (2.7-5.5V)
+VS = io("VS", Power(voltage="2.7V to 5.5V"))  # Power supply (2.7-5.5V)
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Gas/SCD40-D-R2.zen
+++ b/Sensor_Gas/SCD40-D-R2.zen
@@ -16,7 +16,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -47,7 +46,7 @@ add_test_points = config("add_test_points", bool, default=False, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-power = io("power", Power, checks=voltage_within("2.4V to 5.5V"))
+power = io("power", Power(voltage="2.4V to 5.5V"))
 VDD = power
 GND = io("GND", Ground)
 

--- a/Sensor_Gas/SCD41-D-R2.zen
+++ b/Sensor_Gas/SCD41-D-R2.zen
@@ -18,7 +18,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -49,7 +48,7 @@ add_test_points = config("add_test_points", bool, default=False, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-power = io("power", Power, checks=voltage_within("2.4V to 5.5V"))
+power = io("power", Power(voltage="2.4V to 5.5V"))
 VDD = power
 GND = io("GND", Ground)
 

--- a/Sensor_Humidity/SHT30.zen
+++ b/Sensor_Humidity/SHT30.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,7 +55,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.15V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.15V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHT30A.zen
+++ b/Sensor_Humidity/SHT30A.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,7 +55,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.15V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.15V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHT31.zen
+++ b/Sensor_Humidity/SHT31.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,7 +55,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.15V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.15V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHT31A.zen
+++ b/Sensor_Humidity/SHT31A.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,7 +55,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.15V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.15V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHT35.zen
+++ b/Sensor_Humidity/SHT35.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -57,7 +56,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.15V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.15V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHT35A.zen
+++ b/Sensor_Humidity/SHT35A.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,7 +55,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.15V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.15V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHT4x.zen
+++ b/Sensor_Humidity/SHT4x.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -50,7 +49,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.08V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.08V to 3.6V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHTC1.zen
+++ b/Sensor_Humidity/SHTC1.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -41,7 +40,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.62V to 1.98V"))
+VDD = io("VDD", Power(voltage="1.62V to 1.98V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/SHTC1.zen
+++ b/Sensor_Humidity/SHTC1.zen
@@ -62,7 +62,6 @@ Component(
         "SCL": _SCL,
         "SDA": _SDA,
         "VSS": GND,
-        "NC": GND,  # Center pad - internally connected to VSS, connect directly to ground
     },
 )
 

--- a/Sensor_Humidity/SHTC3.zen
+++ b/Sensor_Humidity/SHTC3.zen
@@ -62,7 +62,6 @@ Component(
         "SDA": _SDA,
         "VDD": VDD,
         "VSS": GND,
-        "NC": GND,  # Center pad - internally connected to VSS, connect directly to ground
     },
 )
 

--- a/Sensor_Humidity/SHTC3.zen
+++ b/Sensor_Humidity/SHTC3.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/D
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -41,7 +40,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.62V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.62V to 3.6V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/Si7020-A20.zen
+++ b/Sensor_Humidity/Si7020-A20.zen
@@ -56,7 +56,6 @@ _SCL = i2c.SCL
 _SDA = i2c.SDA
 
 # DNC pins - Do Not Connect pins can be floating or tied to VDD (NOT GND)
-_DNC = Net("DNC")
 
 
 # Digital Humidity and Temperature Sensor, ±4%RH, ±0.4°C, I2C, 1.9-3.6V, DFN-6
@@ -67,7 +66,6 @@ Component(
     pins={
         "SDA": _SDA,  # Pin 1
         "GND": GND,  # Pin 2
-        "NC": _DNC,  # Pins 3,4 - DNC (Do Not Connect) - can be floating or tied to VDD
         "VDD": VDD,  # Pin 5
         "SCL": _SCL,  # Pin 6
         "PAD": GND,  # TGND Paddle - internally connected to GND, main thermal input

--- a/Sensor_Humidity/Si7020-A20.zen
+++ b/Sensor_Humidity/Si7020-A20.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.silabs.com/documents/public/data-sheets/Si7020-A20.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -45,7 +44,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.9V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.9V to 3.6V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/Si7021-A20.zen
+++ b/Sensor_Humidity/Si7021-A20.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -42,7 +41,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.9V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.9V to 3.6V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Humidity/Si7021-A20.zen
+++ b/Sensor_Humidity/Si7021-A20.zen
@@ -53,7 +53,6 @@ _SCL = i2c.SCL
 _SDA = i2c.SDA
 
 # DNC pins - Do Not Connect pins can be floating or tied to VDD (NOT GND)
-_DNC = Net("DNC")
 
 
 # Digital Humidity and Temperature Sensor, ±3%RH, ±0.4°C, I2C, 1.9-3.6V, DFN-6
@@ -64,7 +63,6 @@ Component(
     pins={
         "SDA": _SDA,  # Pin 1
         "GND": GND,  # Pin 2
-        "NC": _DNC,  # Pins 3,4 - DNC (Do Not Connect) - can be floating or tied to VDD
         "VDD": VDD,  # Pin 5
         "SCL": _SCL,  # Pin 6
         "PAD": GND,  # TGND Paddle - internally connected to GND, main thermal input

--- a/Sensor_Magnetic/LIS3MDL.zen
+++ b/Sensor_Magnetic/LIS3MDL.zen
@@ -12,7 +12,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/lis3mdl.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -42,12 +41,12 @@ add_bulk_cap = config("add_bulk_cap", bool, default=True)
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.9V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.9V to 3.6V"))
 GND = io("GND", Ground)
 
 # VDD_IO - can be same as VDD or separate
 if separate_vddio:
-    VDD_IO = io("VDD_IO", Power, checks=voltage_within("1.9V to 3.6V"))
+    VDD_IO = io("VDD_IO", Power(voltage="1.9V to 3.6V"))
 else:
     VDD_IO = VDD
 

--- a/Sensor_Magnetic/LIS3MDL.zen
+++ b/Sensor_Magnetic/LIS3MDL.zen
@@ -75,17 +75,17 @@ else:  # SPI modes
 
 # Interrupt pins
 if enable_interrupt:
-    INT = io("INT", Net, default=Net("INT"))
+    INT = io("INT", Net)
 else:
     INT = NotConnected()
 
 if enable_data_ready:
-    DRDY = io("DRDY", Net, default=Net("DRDY"))
+    DRDY = io("DRDY", Net)
 else:
     DRDY = NotConnected()
 
 # Internal nets
-_C1 = Net("C1")  # External capacitor connection
+_C1 = Power("C1")  # External capacitor connection
 
 # Main component
 Component(

--- a/Sensor_Magnetic/TLV493D.zen
+++ b/Sensor_Magnetic/TLV493D.zen
@@ -37,7 +37,7 @@ i2c_speed = config("i2c_speed", I2cSpeed, default="400kHz")
 # External IO
 VDD = io("VDD", Power)
 GND = io("GND", Ground)
-i2c = io("I2C", I2c, default=I2c())
+i2c = io("I2C", I2c)
 
 # Optional interrupt output
 if enable_interrupt:

--- a/Sensor_Motion/ADXL343.zen
+++ b/Sensor_Motion/ADXL343.zen
@@ -127,7 +127,6 @@ else:
 # Reserved pins - per datasheet requirements
 _RES1 = _VS  # Reserved pin 3 - connect to VS or leave open (we connect to VS)
 _RES2 = GND  # Reserved pin 11 - connect to GND or leave open (we connect to GND)
-_NC = NotConnected()  # Not internally connected
 
 # 3-Axis MEMS Accelerometer, 2/4/8/16g range, I2C/SPI, LGA-14
 Component(
@@ -142,7 +141,6 @@ Component(
         "~{CS}": _CS,
         "INT1": INT1,
         "INT2": INT2,
-        "NC": _NC,
         "SDO/ADDR": _SDO_ADDR,
         "SDA/SDI/SDIO": _SDA_SDI_SDIO,
         "SCL/SCLK": _SCL_SCLK,

--- a/Sensor_Motion/ADXL343.zen
+++ b/Sensor_Motion/ADXL343.zen
@@ -21,7 +21,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/A
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -72,9 +71,9 @@ if use_int1 or use_int2:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VS = io("VS", Power, checks=voltage_within("2V to 3.6V"))
+VS = io("VS", Power(voltage="2V to 3.6V"))
 if separate_vddio:
-    VDD_IO = io("VDD_IO", Power, checks=voltage_within("2V to 3.6V"))
+    VDD_IO = io("VDD_IO", Power(voltage="2V to 3.6V"))
 else:
     VDD_IO = io("VDD_IO", Net, default=VS)
 GND = io("GND", Ground)

--- a/Sensor_Motion/ADXL363.zen
+++ b/Sensor_Motion/ADXL363.zen
@@ -92,8 +92,11 @@ else:
 # ADC input (conditionally exposed)
 if expose_adc_input:
     ADC_IN = io("ADC_IN", Net)
+    # When a filter is added, the chip pin sees the filtered node, not the external io directly.
+    _ADC_PIN = Net("ADC_FILTERED") if add_adc_filter else ADC_IN
 else:
     ADC_IN = Net("ADC_IN_NC")
+    _ADC_PIN = ADC_IN
 
 # Internal nets
 _VS = VS
@@ -115,7 +118,7 @@ Component(
     symbol=Symbol(library="@kicad-symbols/Sensor_Motion.kicad_sym", name="ADXL363"),
     footprint=File("@kicad-footprints/Sensor_Motion.pretty/Analog_LGA-16_3.25x3mm_P0.5mm_LayoutBorder3x5y.kicad_mod"),
     pins={
-        "ADC_IN": ADC_IN,
+        "ADC_IN": _ADC_PIN,
         "MOSI": _MOSI,
         "MISO": _MISO,
         "SCLK": _SCLK,
@@ -155,15 +158,9 @@ if add_interrupt_pullups:
 
 # ADC input filter (if enabled)
 if expose_adc_input and add_adc_filter:
-    # RC low-pass filter for ADC input
-    _ADC_FILTERED = Net("ADC_FILTERED")
-
-    Resistor(name="R_ADC", value="1kohms", package="0402", P1=ADC_IN, P2=_ADC_FILTERED)
-
-    Capacitor(name="C_ADC", value="100nF", voltage="6.3V", package="0402", P1=_ADC_FILTERED, P2=GND)
-
-    # Connect filtered signal to chip
-    ADC_IN = _ADC_FILTERED
+    # RC low-pass filter on the ADC input before the chip pin.
+    Resistor(name="R_ADC", value="1kohms", package="0402", P1=ADC_IN, P2=_ADC_PIN)
+    Capacitor(name="C_ADC", value="100nF", voltage="6.3V", package="0402", P1=_ADC_PIN, P2=GND)
 
 # CS pull-up resistor (ensures SPI mode when not actively driven)
 Resistor(name="R_CS", value="100kohms", package="0402", P1=_CS, P2=_VDD_IO)

--- a/Sensor_Motion/BMI160.zen
+++ b/Sensor_Motion/BMI160.zen
@@ -80,8 +80,8 @@ elif interface_mode == InterfaceMode("SPI3Wire") or interface_mode == InterfaceM
         _SDO = spi.MISO
 
 # Interrupt pins (always exposed)
-INT1 = io("INT1", Net, default=Net("INT1"))
-INT2 = io("INT2", Net, default=Net("INT2"))
+INT1 = io("INT1", Net)
+INT2 = io("INT2", Net)
 
 # Auxiliary interface configuration
 if auxiliary_mode == AuxiliaryMode("None"):
@@ -99,9 +99,9 @@ elif auxiliary_mode == AuxiliaryMode("I2C"):
     _OSDO = NotConnected()
 elif auxiliary_mode == AuxiliaryMode("SPI3Wire"):
     # 3-wire SPI auxiliary interface for OIS (bidirectional data)
-    OIS_CLK = io("OIS_CLK", Net, default=Net("OIS_CLK"))
-    OIS_CS = io("OIS_CS", Net, default=Net("OIS_CS"))
-    OIS_SISO = io("OIS_SISO", Net, default=Net("OIS_SISO"))  # Serial In/Serial Out - bidirectional
+    OIS_CLK = io("OIS_CLK", Net)
+    OIS_CS = io("OIS_CS", Net)
+    OIS_SISO = io("OIS_SISO", Net)  # Serial In/Serial Out - bidirectional
     _ASCx = OIS_CLK
     _OCSB = OIS_CS
     _ASDx = OIS_SISO

--- a/Sensor_Motion/BMI160.zen
+++ b/Sensor_Motion/BMI160.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datash
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -49,10 +48,10 @@ add_vddio_decoupling = config("add_vddio_decoupling", bool, default=True)
 separate_vddio = config("separate_vddio", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.71V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.71V to 3.6V"))
 # VDDIO - can be same as VDD or separate
 if separate_vddio:
-    VDDIO = io("VDDIO", Power, checks=voltage_within("1.71V to 3.6V"))
+    VDDIO = io("VDDIO", Power(voltage="1.71V to 3.6V"))
 else:
     VDDIO = VDD
 GND = io("GND", Ground)

--- a/Sensor_Motion/BNO055.zen
+++ b/Sensor_Motion/BNO055.zen
@@ -36,12 +36,12 @@ add_boot_pullup = config("add_boot_pullup", bool, default=True)
 VDD = io("VDD", Power)
 VDDIO = VDD  # Connect VDDIO to VDD
 GND = io("GND", Ground)
-RESET = io("RESET", Net, default=Net("nRESET"))
-INT = io("INT", Net, default=Net("INT"))
+RESET = io("RESET", Net)
+INT = io("INT", Net)
 
 # Interface IO based on mode
 if interface_mode == InterfaceMode("I2C") or interface_mode == InterfaceMode("HID_I2C"):
-    i2c = io("I2C", I2c, default=I2c("I2C"))
+    i2c = io("I2C", I2c)
     _COM0 = i2c.SDA
     _COM1 = i2c.SCL
     _COM2 = GND if i2c_address == I2cAddress("0x28") else VDDIO
@@ -96,21 +96,10 @@ Component(
         "COM1": _COM1,
         "COM2": _COM2,
         "COM3": _COM3,
-        "PIN1": GND,
-        "PIN7": GND,
-        "PIN8": GND,
         "VDD": VDD,
         "GND": GND,
         "VDDIO": VDDIO,
         "GNDIO": GND,
-        "PIN15": GND,
-        "PIN16": GND,
-        "PIN12": GND,
-        "PIN13": GND,
-        "PIN21": GND,
-        "PIN22": GND,
-        "PIN23": GND,
-        "PIN24": GND,
         "XOUT32": _XOUT32,
         "XIN32": _XIN32,
         "PS0": _PS0,

--- a/Sensor_Motion/ICM-20602.zen
+++ b/Sensor_Motion/ICM-20602.zen
@@ -23,7 +23,6 @@ Datasheet: https://invensense.tdk.com/wp-content/uploads/2016/10/DS-000176-ICM-2
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -59,10 +58,10 @@ if use_interrupt:
 use_fsync = config("use_fsync", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.71V to 3.45V"))
+VDD = io("VDD", Power(voltage="1.71V to 3.45V"))
 # VDDIO - can be same as VDD or separate
 if separate_vddio:
-    VDDIO = io("VDDIO", Power, checks=voltage_within("1.71V to 3.45V"))
+    VDDIO = io("VDDIO", Power(voltage="1.71V to 3.45V"))
 else:
     VDDIO = VDD
 GND = io("GND", Ground)

--- a/Sensor_Motion/ICM-20602.zen
+++ b/Sensor_Motion/ICM-20602.zen
@@ -88,8 +88,6 @@ else:
 
 # Internal nets
 _REGOUT = Net("REGOUT")
-_SAO_SD0 = Net("SAO_SD0")
-_CS = Net("CS")
 
 # Interface Mode Configuration
 if interface_mode == InterfaceMode("I2C"):
@@ -136,7 +134,6 @@ Component(
         "SDA/SDI": _SDA_SDI,
         "SCL/SPC": _SCL_SPC,
         "~{CS}": _CS,
-        "RESV": GND,
         "VDD": VDD,
         "GND": GND,
         "VDDIO": VDDIO,

--- a/Sensor_Motion/ICM-20948.zen
+++ b/Sensor_Motion/ICM-20948.zen
@@ -22,7 +22,6 @@ Datasheet: https://invensense.tdk.com/wp-content/uploads/2016/06/DS-000189-ICM-2
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -49,13 +48,13 @@ add_vdd_bypass_cap = config("add_vdd_bypass_cap", bool, default=True)
 seperate_vdd_vddio = config("seperate_vdd_vddio", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.71V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.71V to 3.6V"))
 GND = io("GND", Ground)
 
 
 if seperate_vdd_vddio:
     add_vddio_bypass_cap = config("add_vddio_bypass_cap", bool, default=True)
-    VDDIO = io("VDDIO", Power, checks=voltage_within("1.71V to 3.6V"))
+    VDDIO = io("VDDIO", Power(voltage="1.71V to 3.6V"))
 else:
     add_vddio_bypass_cap = False
     VDDIO = VDD

--- a/Sensor_Motion/ICM-20948.zen
+++ b/Sensor_Motion/ICM-20948.zen
@@ -93,11 +93,6 @@ if use_aux_i2c:
 
 # Internal nets
 _REGOUT = Net("REGOUT")
-_NC = NotConnected()
-_RESV_19 = Net("RESV_19")
-_RESV_20 = Net("RESV_20")
-_ADO_SDO = Net("ADO_SDO")
-_CS = Net("CS")
 
 # Interface Mode Configuration
 if interface_mode == InterfaceMode("I2C"):
@@ -143,18 +138,12 @@ if use_fsync:
 else:
     _FSYNC_PIN = GND  # Connect to GND if unused per datasheet
 
-# Reserved pins
-# Pin 19 (RESV) - Do not connect per datasheet
-# Pin 20 (RESV) - Connect to GND per datasheet# Connect RESV pin 20 to GND as per datasheet
-_RESV_20 = GND
-
 # ICM-20948 Component
 Component(
     name="ICM-20948",
     symbol=Symbol(library="@kicad-symbols/Sensor_Motion.kicad_sym", name="ICM-20948"),
     footprint=File("@kicad-footprints/Sensor_Motion.pretty/InvenSense_QFN-24_3x3mm_P0.4mm.kicad_mod"),
     pins={
-        "NC": _NC,
         "AUX_CL": _AUX_CL,
         "VDDIO": VDDIO,
         "SDO/AD0": _ADO_SDO,
@@ -163,7 +152,6 @@ Component(
         "INT1": _INT1_PIN,
         "VDD": VDD,
         "GND": GND,
-        "RESV": _RESV_20,  # Pin 20 - Connect to GND
         "AUX_DA": _AUX_DA,
         "~{CS}": _CS,
         "SCL/SCLK": _SCL_SCLK,

--- a/Sensor_Motion/ISM330DHCX.zen
+++ b/Sensor_Motion/ISM330DHCX.zen
@@ -55,34 +55,38 @@ add_decoupling_caps = config("add_decoupling", bool, default=True, optional=True
 
 # External IO
 VDD = io("VDD", Power)
-VDDIO = io("VDDIO", Net, default=VDD)
+VDDIO = io("VDDIO", Power, optional=True)
+if VDDIO == None:
+    _VDDIO = VDD
+else:
+    _VDDIO = VDDIO
 GND = io("GND", Ground)
 
 # Interrupt pins
-INT1 = io("INT1", Net, default=Net("INT1"))
-INT2 = io("INT2", Net, default=Net("INT2"))
+INT1 = io("INT1", Net)
+INT2 = io("INT2", Net)
 
 # Mode-specific auxiliary interface IOs
 if interface_mode == InterfaceMode("Mode2"):
     # Master I2C interface for external sensors
-    MSDA = io("MSDA", Net, default=Net("MSDA"))
-    MSCL = io("MSCL", Net, default=Net("MSCL"))
+    MSDA = io("MSDA", Net)
+    MSCL = io("MSCL", Net)
 elif interface_mode == InterfaceMode("Mode3") or interface_mode == InterfaceMode("Mode4"):
     # Auxiliary SPI interface
-    SDI_AUX = io("SDI_AUX", Net, default=Net("SDI_AUX"))
-    SPC_AUX = io("SPC_AUX", Net, default=Net("SPC_AUX"))
-    OCS_AUX = io("OCS_AUX", Net, default=Net("OCS_AUX"))
-    SDO_AUX = io("SDO_AUX", Net, default=Net("SDO_AUX"))
+    SDI_AUX = io("SDI_AUX", Net)
+    SPC_AUX = io("SPC_AUX", Net)
+    OCS_AUX = io("OCS_AUX", Net)
+    SDO_AUX = io("SDO_AUX", Net)
 
 # Interface selection
 if interface_type == InterfaceType("I2C"):
-    i2c = io("I2C", I2c, default=I2c("I2C"))
+    i2c = io("I2C", I2c)
     _CS = VDD  # CS must be tied high for I2C mode
     _SCL = i2c.SCL
     _SDA = i2c.SDA
     _SDO_SA0 = GND if i2c_address == I2cAddress("0x6A") else VDD
 else:  # SPI mode
-    spi = io("SPI", Spi, default=Spi("SPI"))
+    spi = io("SPI", Spi)
     _CS = spi.CS
     _SCL = spi.CLK
     _SDA = spi.MOSI
@@ -121,7 +125,7 @@ Component(
         "INT1": INT1,
         "INT2": INT2,
         "VDD": VDD,
-        "VDDIO": VDDIO,
+        "VDDIO": _VDDIO,
         "GND": GND,
         "SDx": _SDx,
         "SCx": _SCx,
@@ -139,23 +143,23 @@ if add_decoupling_caps:
     Capacitor(name="C_VDD", value="100nF", package="0402", P1=VDD, P2=GND)
 
     # VDDIO decoupling - 100nF ceramic close to pin
-    Capacitor(name="C_VDDIO", value="100nF", package="0402", P1=VDDIO, P2=GND)
+    Capacitor(name="C_VDDIO", value="100nF", package="0402", P1=_VDDIO, P2=GND)
 
 # I2C Pull-up Resistors
 if add_i2c_pullups and interface_type == InterfaceType("I2C"):
     # Typical 4.7k pull-ups for I2C
-    Resistor(name="R_SCL", value="4.7kohms", package="0402", P1=_SCL, P2=VDDIO)
-    Resistor(name="R_SDA", value="4.7kohms", package="0402", P1=_SDA, P2=VDDIO)
+    Resistor(name="R_SCL", value="4.7kohms", package="0402", P1=_SCL, P2=_VDDIO)
+    Resistor(name="R_SDA", value="4.7kohms", package="0402", P1=_SDA, P2=_VDDIO)
 
 # Interrupt pull-ups (optional, depends on host configuration)
 if add_interrupt_pullups:
-    Resistor(name="R_INT1", value="10kohms", package="0402", P1=INT1, P2=VDDIO)
-    Resistor(name="R_INT2", value="10kohms", package="0402", P1=INT2, P2=VDDIO)
+    Resistor(name="R_INT1", value="10kohms", package="0402", P1=INT1, P2=_VDDIO)
+    Resistor(name="R_INT2", value="10kohms", package="0402", P1=INT2, P2=_VDDIO)
 
 # Mode 2: Master I2C pull-ups for external sensors
 if add_master_pullups and interface_mode == InterfaceMode("Mode2"):
-    Resistor(name="R_MSCL", value="4.7kohms", package="0402", P1=_SCx, P2=VDDIO)
-    Resistor(name="R_MSDA", value="4.7kohms", package="0402", P1=_SDx, P2=VDDIO)
+    Resistor(name="R_MSCL", value="4.7kohms", package="0402", P1=_SCx, P2=_VDDIO)
+    Resistor(name="R_MSDA", value="4.7kohms", package="0402", P1=_SDx, P2=_VDDIO)
 
 # pcb:sch C_BULK.C x=994.6800 y=214.9000 rot=0
 # pcb:sch C_VDD.C x=816.8800 y=214.9000 rot=0

--- a/Sensor_Motion/LIS331HH.zen
+++ b/Sensor_Motion/LIS331HH.zen
@@ -89,8 +89,8 @@ else:  # SPI modes
 
 # Interrupt pins
 if enable_interrupts:
-    INT1 = io("INT1", Net, default=Net("INT1"))
-    INT2 = io("INT2", Net, default=Net("INT2"))
+    INT1 = io("INT1", Net)
+    INT2 = io("INT2", Net)
 else:
     INT1 = NotConnected()
     INT2 = NotConnected()
@@ -110,7 +110,6 @@ Component(
         "INT2": INT2,
         "Vdd": VDD,
         "GND": GND,
-        "NC": NotConnected(),
     },
 )
 

--- a/Sensor_Motion/LIS331HH.zen
+++ b/Sensor_Motion/LIS331HH.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/lis331hh.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -56,10 +55,10 @@ else:
     add_vddio_decoupling = False
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("2.16V to 3.6V"))
+VDD = io("VDD", Power(voltage="2.16V to 3.6V"))
 # VDD_IO - can be same as VDD or separate
 if separate_vddio:
-    VDD_IO = io("VDD_IO", Power, checks=voltage_within("2.16V to 3.6V"))
+    VDD_IO = io("VDD_IO", Power(voltage="2.16V to 3.6V"))
 else:
     VDD_IO = VDD
 GND = io("GND", Ground)

--- a/Sensor_Motion/LIS3DH.zen
+++ b/Sensor_Motion/LIS3DH.zen
@@ -86,24 +86,24 @@ else:  # SPI modes
 
 # Interrupt pins
 if enable_interrupts:
-    INT1 = io("INT1", Net, default=Net("INT1"))
-    INT2 = io("INT2", Net, default=Net("INT2"))
+    INT1 = io("INT1", Net)
+    INT2 = io("INT2", Net)
 else:
     INT1 = NotConnected()
     INT2 = NotConnected()
 
 # ADC pins
 if enable_adc:
-    ADC1 = io("ADC1", Net, default=Net("ADC1"))
-    ADC2 = io("ADC2", Net, default=Net("ADC2"))
-    ADC3 = io("ADC3", Net, default=Net("ADC3"))
+    ADC1 = io("ADC1", Net)
+    ADC2 = io("ADC2", Net)
+    ADC3 = io("ADC3", Net)
 else:
     ADC1 = NotConnected()
     ADC2 = NotConnected()
     ADC3 = NotConnected()
 
 # Internal nets
-_RES = Net("RES")  # Reserved pin, must be connected to GND
+_RES = GND  # Reserved pin, must be connected to GND
 
 # Main component
 Component(
@@ -120,7 +120,6 @@ Component(
         "INT2": INT2,
         "VDD": VDD,
         "GND": GND,
-        "NC": NotConnected(),
         "ADC1": ADC1,
         "ADC2": ADC2,
         "ADC3": ADC3,
@@ -128,7 +127,6 @@ Component(
 )
 
 # Connect RES pin to GND (required)
-_RES = GND
 
 # Power supply decoupling
 if add_decoupling:

--- a/Sensor_Motion/LSM303C.zen
+++ b/Sensor_Motion/LSM303C.zen
@@ -16,7 +16,6 @@ Datasheet: https://www.st.com/resource/en/datasheet/lsm303c.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Spi", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -46,9 +45,9 @@ enable_int_mag = config("enable_int_mag", bool, default=True)
 enable_drdy_mag = config("enable_drdy_mag", bool, default=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.9V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.9V to 3.6V"))
 if seperate_vdd_vddio:
-    VDD_IO = io("VDD_IO", Power, checks=voltage_within("1.9V to 3.6V"))
+    VDD_IO = io("VDD_IO", Power(voltage="1.9V to 3.6V"))
 else:
     VDD_IO = VDD
 GND = io("GND", Ground)

--- a/Sensor_Motion/MPU-6050.zen
+++ b/Sensor_Motion/MPU-6050.zen
@@ -31,21 +31,24 @@ i2c_address = config("i2c_address", I2cAddress, default="0x68")
 enable_interrupt = config("enable_interrupt", bool, default=True)
 
 # External IO
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 VDD = io("VDD", Power)
-VLOGIC = io("VLOGIC", Net, default=VDD)
+VLOGIC = io("VLOGIC", Power, optional=True)
+_VLOGIC = VLOGIC if VLOGIC != None else VDD
 GND = io("GND", Ground)
-INT = io("INT", Net, default=Net("INT")) if enable_interrupt else None
+INT = io("INT", Net) if enable_interrupt else None
 
 # Optional external clock input
-CLKIN = io("CLKIN", Net, default=GND)
+CLKIN = io("CLKIN", Net, optional=True)
+_CLKIN = CLKIN if CLKIN != None else GND
 
 # Optional frame sync input
-FSYNC = io("FSYNC", Net, default=GND)
+FSYNC = io("FSYNC", Net, optional=True)
+_FSYNC = FSYNC if FSYNC != None else GND
 
 # Auxiliary I2C interface (optional)
-AUX_DA = io("AUX_DA", Net, default=Net("AUX_DA"), optional=True)
-AUX_CL = io("AUX_CL", Net, default=Net("AUX_CL"), optional=True)
+AUX_DA = io("AUX_DA", Net, optional=True)
+AUX_CL = io("AUX_CL", Net, optional=True)
 
 # Internal nets
 _AD0 = GND if i2c_address == I2cAddress("0x68") else VDD
@@ -53,7 +56,6 @@ _REGOUT = Net("REGOUT")
 _CPOUT = Net("CPOUT")
 
 # Reserved pins - must not be connected
-_RESV = Net("RESV")
 
 # Handle conditional nets
 _INT = INT if enable_interrupt else NotConnected()
@@ -73,13 +75,11 @@ Component(
         "SDA": _SDA,
         "SCL": _SCL,
         "AD0": _AD0,
-        "FSYNC": FSYNC,
-        "CLKIN": CLKIN,
-        "NC": NotConnected(),
-        "VLOGIC": VLOGIC,
+        "FSYNC": _FSYNC,
+        "CLKIN": _CLKIN,
+        "VLOGIC": _VLOGIC,
         "GND": GND,
         "VDD": VDD,
-        "RESV": _RESV,
         "INT": _INT,
         "AUX_DA": _AUX_DA,
         "AUX_CL": _AUX_CL,
@@ -92,7 +92,7 @@ Component(
 Capacitor(name="C_VDD", value="100nF", package="0402", P1=VDD, P2=GND, dnp=not add_decoupling)
 
 # VLOGIC Bypass Capacitor - Required for MPU-6050
-Capacitor(name="C_VLOGIC", value="10nF", package="0402", P1=VLOGIC, P2=GND, dnp=not add_vlogic_cap)
+Capacitor(name="C_VLOGIC", value="10nF", package="0402", P1=_VLOGIC, P2=GND, dnp=not add_vlogic_cap)
 
 # Regulator Filter Capacitor - Required on REGOUT pin
 Capacitor(name="C_REGOUT", value="100nF", package="0402", P1=_REGOUT, P2=GND, dnp=not add_regout_cap)

--- a/Sensor_Motion/MPU-9250.zen
+++ b/Sensor_Motion/MPU-9250.zen
@@ -45,33 +45,35 @@ enable_interrupt = config("enable_interrupt", bool, default=True)
 VDD = io("VDD", Power)
 if separate_vddio:
     VDDIO = io("VDDIO", Power)
+    _VDDIO = VDDIO
 else:
-    VDDIO = io("VDDIO", Power, default=VDD)
+    VDDIO = io("VDDIO", Power, optional=True)
+    _VDDIO = VDDIO if VDDIO != None else VDD
 GND = io("GND", Ground)
 
 # Interface connections
 if interface_type == Interface("I2C"):
-    i2c = io("I2C", I2c, default=I2c("I2C"))
+    i2c = io("I2C", I2c)
     _SDA = i2c.SDA
     _SCL = i2c.SCL
     _CS = Net("CS_PULLUP")  # CS will be pulled high via resistor to disable SPI interface
 else:
-    spi = io("SPI", Spi, default=Spi("SPI"))
+    spi = io("SPI", Spi)
     _SDA = spi.MOSI
     _SCL = spi.CLK
     _CS = spi.CS
 
 # Optional interrupt
 if enable_interrupt:
-    INT = io("INT", Net, default=Net("INT"))
+    INT = io("INT", Net)
     _INT = INT
 else:
     _INT = NotConnected()
 
 # Optional auxiliary I2C interface
 if add_aux_i2c:
-    AUX_DA = io("AUX_DA", Net, default=Net("AUX_DA"))
-    AUX_CL = io("AUX_CL", Net, default=Net("AUX_CL"))
+    AUX_DA = io("AUX_DA", Net)
+    AUX_CL = io("AUX_CL", Net)
     _AUX_DA = AUX_DA
     _AUX_CL = AUX_CL
 else:
@@ -80,15 +82,16 @@ else:
     _AUX_CL = NotConnected()
 
 # Frame sync input (optional)
-FSYNC = io("FSYNC", Net, default=GND)
+FSYNC = io("FSYNC", Net, optional=True)
+_FSYNC = FSYNC if FSYNC != None else GND
 
 # Internal nets
-_AD0 = GND if interface_type == Interface("I2C") and i2c_address == I2cAddress("0x68") else VDDIO
+_AD0 = GND if interface_type == Interface("I2C") and i2c_address == I2cAddress("0x68") else _VDDIO
 _SDO = spi.MISO if interface_type == Interface("SPI") else _AD0
 _REGOUT = Net("REGOUT")
 
 # Reserved pins - connect as specified in datasheet
-_RESV_VDDIO = VDDIO  # Reserved, connect to VDDIO
+_RESV_VDDIO = _VDDIO  # Reserved, connect to VDDIO
 _RESV_GND = GND  # Reserved, connect to GND
 
 # InvenSense 9-Axis Motion Sensor, Accelerometer, Gyroscope, Magnetometer, I2C/SPI, 3x3mm
@@ -101,8 +104,8 @@ Component(
         "AD0/MISO": _SDO,  # ADO/SDO - I2C Address LSB / SPI Data Out
         "SCL/SCLK": _SCL,  # SCL/SCLK - I2C Clock / SPI Clock
         "~{CS}": _CS,  # nCS - Chip select (SPI mode only)
-        "FSYNC": FSYNC,  # FSYNC - Frame sync input
-        "VDDIO": VDDIO,  # VDDIO - Digital I/O supply voltage
+        "FSYNC": _FSYNC,  # FSYNC - Frame sync input
+        "VDDIO": _VDDIO,  # VDDIO - Digital I/O supply voltage
         "GND": GND,  # GND - Power supply ground
         "VDD": VDD,  # VDD - Power supply
         "INT": _INT,  # INT - Interrupt output
@@ -120,7 +123,7 @@ if add_decoupling:
     Capacitor(name="C_VDD", value="100nF", package="0402", P1=VDD, P2=GND)
 
     # VDDIO decoupling capacitor - per datasheet BOM: 10nF, 4V
-    Capacitor(name="C_VDDIO", value="10nF", package="0402", P1=VDDIO, P2=GND)
+    Capacitor(name="C_VDDIO", value="10nF", package="0402", P1=_VDDIO, P2=GND)
 
 # Regulator Filter Capacitor - Required on REGOUT pin per datasheet BOM: 100nF, 2V
 Capacitor(name="C_REGOUT", value="100nF", package="0402", P1=_REGOUT, P2=GND, dnp=not add_regout_cap)
@@ -128,21 +131,21 @@ Capacitor(name="C_REGOUT", value="100nF", package="0402", P1=_REGOUT, P2=GND, dn
 # I2C Pull-up Resistors - Required for proper I2C operation
 if add_i2c_pullups and interface_type == Interface("I2C"):
     # Standard 4.7k pull-ups for I2C
-    Resistor(name="R_SDA", value="4.7kohms", package="0402", P1=_SDA, P2=VDDIO)
-    Resistor(name="R_SCL", value="4.7kohms", package="0402", P1=_SCL, P2=VDDIO)
+    Resistor(name="R_SDA", value="4.7kohms", package="0402", P1=_SDA, P2=_VDDIO)
+    Resistor(name="R_SCL", value="4.7kohms", package="0402", P1=_SCL, P2=_VDDIO)
 
 # Auxiliary I2C pull-ups - independent of main interface mode
 if add_aux_i2c and add_aux_i2c_pullups:
-    Resistor(name="R_AUX_DA", value="4.7kohms", package="0402", P1=_AUX_DA, P2=VDDIO)
-    Resistor(name="R_AUX_CL", value="4.7kohms", package="0402", P1=_AUX_CL, P2=VDDIO)
+    Resistor(name="R_AUX_DA", value="4.7kohms", package="0402", P1=_AUX_DA, P2=_VDDIO)
+    Resistor(name="R_AUX_CL", value="4.7kohms", package="0402", P1=_AUX_CL, P2=_VDDIO)
 
 # Interrupt pull-up resistor (optional but recommended)
-Resistor(name="R_INT", value="10kohms", package="0402", P1=INT, P2=VDDIO, dnp=not enable_interrupt)
+Resistor(name="R_INT", value="10kohms", package="0402", P1=INT, P2=_VDDIO, dnp=not enable_interrupt)
 
 # SPI interface pull-up for CS (when using I2C mode to disable SPI)
 if interface_type == Interface("I2C"):
     # Pull CS high to disable SPI interface when using I2C
-    Resistor(name="R_CS_PULLUP", value="10kohms", package="0402", P1=_CS, P2=VDDIO)
+    Resistor(name="R_CS_PULLUP", value="10kohms", package="0402", P1=_CS, P2=_VDDIO)
 
 # pcb:sch C_REGOUT.C x=715.2800 y=761.0000 rot=0
 # pcb:sch C_VDD.C x=-97.5200 y=646.7000 rot=0

--- a/Sensor_Optical/ISL29035.zen
+++ b/Sensor_Optical/ISL29035.zen
@@ -12,7 +12,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.renesas.com/us/en/www/doc/datasheet/isl29035.pdf
 """
 
-load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
 load("@stdlib/checks.zen", "voltage_within")
 
@@ -45,14 +45,13 @@ i2c = io("I2C", I2c)
 INT = io("INT", Net)
 
 # Internal nets
-_NC = NotConnected()
 
 # Main sensor component
 Component(
     name="ISL29035",
     symbol=Symbol(library="@kicad-symbols/Sensor_Optical.kicad_sym", name="ISL29035"),
     footprint=File("@kicad-footprints/OptoDevice.pretty/Renesas_DFN-6_1.5x1.6mm_P0.5mm.kicad_mod"),
-    pins={"NC": _NC, "VDD": VDD, "GND": GND, "SDA": i2c.SDA, "SCL": i2c.SCL, "~INT": INT},
+    pins={"VDD": VDD, "GND": GND, "SDA": i2c.SDA, "SCL": i2c.SCL, "~INT": INT},
 )
 
 # Power supply decoupling - as per datasheet recommendations (Figure 1)

--- a/Sensor_Optical/ISL29035.zen
+++ b/Sensor_Optical/ISL29035.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.renesas.com/us/en/www/doc/datasheet/isl29035.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -35,7 +34,7 @@ if add_interrupt_pullup:
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IOs
-VDD = io("VDD", Power, checks=voltage_within("2.25V to 3.63V"))
+VDD = io("VDD", Power(voltage="2.25V to 3.63V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Temperature/LM20BIM7.zen
+++ b/Sensor_Temperature/LM20BIM7.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm20.pdf
 """
 
-load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Voltage")
 load("@stdlib/checks.zen", "voltage_within")
 
@@ -45,7 +45,6 @@ VOUT = io("VOUT", Net)  # Temperature sensor analog output
 
 # Internal nets
 _VOUT_FILTERED = Net("VOUT_FILTERED") if add_output_filtering else VOUT
-_NC = NotConnected()  # Not connected pin
 
 # LM20 Temperature Sensor Component
 Component(
@@ -56,7 +55,6 @@ Component(
         "V+": VCC,
         "GND": GND,
         "GND/DIE": GND if connect_die_ground else Net("DIE_GND"),
-        "NC": _NC,
         "VO": _VOUT_FILTERED if add_output_filtering else VOUT,
     },
 )

--- a/Sensor_Temperature/LM20BIM7.zen
+++ b/Sensor_Temperature/LM20BIM7.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm20.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Voltage")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -39,7 +38,7 @@ connect_die_ground = config("connect_die_ground", bool, default=True)
 supply_voltage = config("supply_voltage", Voltage, default="3.3V")  # Supply voltage (2.4V to 5.5V)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.4V to 5.5V"))  # Power supply input (2.4V to 5.5V)
+VCC = io("VCC", Power(voltage="2.4V to 5.5V"))  # Power supply input (2.4V to 5.5V)
 GND = io("GND", Ground)
 VOUT = io("VOUT", Net)  # Temperature sensor analog output
 

--- a/Sensor_Temperature/LM20CIM7.zen
+++ b/Sensor_Temperature/LM20CIM7.zen
@@ -13,7 +13,7 @@ Reviewer: Nasheed Ur Rehman
 Datasheet: https://www.ti.com/lit/ds/symlink/lm20.pdf
 """
 
-load("@stdlib/interfaces.zen", "Power", "Ground", "NotConnected")
+load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Voltage")
 load("@stdlib/checks.zen", "voltage_within")
 
@@ -45,7 +45,6 @@ VOUT = io("VOUT", Net)  # Temperature sensor analog output
 
 # Internal nets
 _VOUT_FILTERED = Net("VOUT_FILTERED") if add_output_filtering else VOUT
-_NC = NotConnected()  # Not connected pin
 
 # LM20 Temperature Sensor Component
 Component(
@@ -56,7 +55,6 @@ Component(
         "V+": VCC,
         "GND": GND,
         "GND/DIE": GND if connect_die_ground else Net("DIE_GND"),
-        "NC": _NC,
         "VO": _VOUT_FILTERED if add_output_filtering else VOUT,
     },
 )

--- a/Sensor_Temperature/LM20CIM7.zen
+++ b/Sensor_Temperature/LM20CIM7.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm20.pdf
 
 load("@stdlib/interfaces.zen", "Power", "Ground")
 load("@stdlib/units.zen", "Voltage")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -39,7 +38,7 @@ connect_die_ground = config("connect_die_ground", bool, default=True)
 supply_voltage = config("supply_voltage", Voltage, default="3.3V")  # Supply voltage (2.4V to 5.5V)
 
 # External IO
-VCC = io("VCC", Power, checks=voltage_within("2.4V to 5.5V"))  # Power supply input (2.4V to 5.5V)
+VCC = io("VCC", Power(voltage="2.4V to 5.5V"))  # Power supply input (2.4V to 5.5V)
 GND = io("GND", Ground)
 VOUT = io("VOUT", Net)  # Temperature sensor analog output
 

--- a/Sensor_Temperature/LM73-1.zen
+++ b/Sensor_Temperature/LM73-1.zen
@@ -31,10 +31,10 @@ i2c_address = config("i2c_address", I2cAddress, default="0x4C")
 resolution = config("resolution", Resolution, default="11bit")
 
 # External IO
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 VDD = io("VDD", Power, checks=voltage_within("1V to 2.7V"))
 GND = io("GND", Ground)
-ALERT = io("ALERT", Net, default=Net("ALERT")) if enable_alert else None
+ALERT = io("ALERT", Net) if enable_alert else None
 
 # Address configuration
 _ADDR = GND if i2c_address == I2cAddress("0x4D") else VDD if i2c_address == I2cAddress("0x4E") else Net("ADDR_FLOAT")

--- a/Sensor_Temperature/LM73-1.zen
+++ b/Sensor_Temperature/LM73-1.zen
@@ -13,7 +13,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/lm73.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -32,7 +31,7 @@ resolution = config("resolution", Resolution, default="11bit")
 
 # External IO
 i2c = io("I2C", I2c)
-VDD = io("VDD", Power, checks=voltage_within("1V to 2.7V"))
+VDD = io("VDD", Power(voltage="1V to 2.7V"))
 GND = io("GND", Ground)
 ALERT = io("ALERT", Net) if enable_alert else None
 

--- a/Sensor_Temperature/MAX31820.zen
+++ b/Sensor_Temperature/MAX31820.zen
@@ -28,7 +28,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "OneWire", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -61,7 +60,7 @@ add_test_points = config("add_test_points", bool, default=True)
 passives_size = config("passives_size", PassiveSize, default="0603")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("3V to 3.7V"))
+VDD = io("VDD", Power(voltage="3V to 3.7V"))
 GND = io("GND", Ground)
 
 # 1-Wire interface

--- a/Sensor_Temperature/MAX31826.zen
+++ b/Sensor_Temperature/MAX31826.zen
@@ -26,7 +26,6 @@ Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/M
 
 load("@stdlib/interfaces.zen", "OneWire", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -102,7 +101,7 @@ add_test_points = config("add_test_points", bool, default=True)
 passives_size = config("passives_size", PassiveSize, default="0603")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("3V to 3.7V"))
+VDD = io("VDD", Power(voltage="3V to 3.7V"))
 GND = io("GND", Ground)
 
 # 1-Wire interface

--- a/Sensor_Temperature/MAX31826.zen
+++ b/Sensor_Temperature/MAX31826.zen
@@ -168,7 +168,6 @@ Component(
     pins={
         "V_{DD}": _VDD_CHIP,  # Pin 1 - Power supply (GND in parasite mode)
         "DQ": _DQ,  # Pin 2 - 1-Wire data
-        "NC": NotConnected(),  # Pin 3 - No connection
         "GND": GND,  # Pin 4 - Ground
         "AD0": _AD0,  # Pin 5 - Address bit 0 (LSB)
         "AD1": _AD1,  # Pin 6 - Address bit 1

--- a/Sensor_Temperature/MCP9808.zen
+++ b/Sensor_Temperature/MCP9808.zen
@@ -13,7 +13,6 @@ Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -32,7 +31,7 @@ i2c_address = config("i2c_address", I2cAddress, default="0x18")
 
 # External IO
 i2c = io("I2C", I2c)
-VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="2.7V to 5.5V"))
 GND = io("GND", Ground)
 ALERT = io("ALERT", Net) if enable_alert else None
 

--- a/Sensor_Temperature/MCP9808.zen
+++ b/Sensor_Temperature/MCP9808.zen
@@ -31,10 +31,10 @@ alert_polarity = config("alert_polarity", AlertPolarity, default="ActiveLow")
 i2c_address = config("i2c_address", I2cAddress, default="0x18")
 
 # External IO
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 VDD = io("VDD", Power, checks=voltage_within("2.7V to 5.5V"))
 GND = io("GND", Ground)
-ALERT = io("ALERT", Net, default=Net("ALERT")) if enable_alert else None
+ALERT = io("ALERT", Net) if enable_alert else None
 
 # Address configuration nets
 _A0 = (

--- a/Sensor_Temperature/MCP9844.zen
+++ b/Sensor_Temperature/MCP9844.zen
@@ -13,7 +13,6 @@ Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -32,7 +31,7 @@ i2c_address = config("i2c_address", I2cAddress, default="0x18")
 
 # External IO
 i2c = io("I2C", I2c)
-VDD = io("VDD", Power, checks=voltage_within("1.7V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.7V to 3.6V"))
 GND = io("GND", Ground)
 EVENT = io("EVENT", Net) if enable_event else None
 

--- a/Sensor_Temperature/MCP9844.zen
+++ b/Sensor_Temperature/MCP9844.zen
@@ -31,10 +31,10 @@ event_polarity = config("event_polarity", EventPolarity, default="ActiveLow")
 i2c_address = config("i2c_address", I2cAddress, default="0x18")
 
 # External IO
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 VDD = io("VDD", Power, checks=voltage_within("1.7V to 3.6V"))
 GND = io("GND", Ground)
-EVENT = io("EVENT", Net, default=Net("EVENT")) if enable_event else None
+EVENT = io("EVENT", Net) if enable_event else None
 
 # Address configuration nets
 _A0 = (

--- a/Sensor_Temperature/TMP114.zen
+++ b/Sensor_Temperature/TMP114.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/tmp114.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -46,7 +45,7 @@ add_test_points = config("add_test_points", bool, default=True, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.08V to 1.98V"))
+VDD = io("VDD", Power(voltage="1.08V to 1.98V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Temperature/TMP116.zen
+++ b/Sensor_Temperature/TMP116.zen
@@ -14,7 +14,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/tmp116.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "Gpio", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -52,7 +51,7 @@ add_test_points = config("add_test_points", bool, default=False, optional=True)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.9V to 5.5V"))
+VDD = io("VDD", Power(voltage="1.9V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Temperature/TMP119AIYBGR.zen
+++ b/Sensor_Temperature/TMP119AIYBGR.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.ti.com/lit/ds/symlink/tmp119.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground", "NotConnected")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -53,7 +52,7 @@ add_test_points = config("add_test_points", bool, default=False)
 passives_size = config("passives_size", str, default="0402")
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.7V to 5.5V"))
+VDD = io("VDD", Power(voltage="1.7V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Touch/CAP1206-.zen
+++ b/Sensor_Touch/CAP1206-.zen
@@ -17,7 +17,6 @@ Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/00001567B.pdf
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
 load("@stdlib/units.zen", "Resistance")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -54,7 +53,7 @@ if add_i2c_pullups:
 add_test_points = config("add_test_points", bool, default=True, optional=True)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("3V to 5.5V"))
+VDD = io("VDD", Power(voltage="3V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface

--- a/Sensor_Touch/CAP1206-.zen
+++ b/Sensor_Touch/CAP1206-.zen
@@ -58,18 +58,18 @@ VDD = io("VDD", Power, checks=voltage_within("3V to 5.5V"))
 GND = io("GND", Ground)
 
 # I2C interface
-i2c = io("I2C", I2c, default=I2c("I2C"))
+i2c = io("I2C", I2c)
 
 # ALERT# output
-ALERT = io("ALERT", Net, default=Net("ALERT#"))
+ALERT = io("ALERT", Net)
 
 # Touch sensor inputs
-CS1 = io("CS1", Net, default=Net("CS1"))
-CS2 = io("CS2", Net, default=Net("CS2"))
-CS3 = io("CS3", Net, default=Net("CS3"))
-CS4 = io("CS4", Net, default=Net("CS4"))
-CS5 = io("CS5", Net, default=Net("CS5"))
-CS6 = io("CS6", Net, default=Net("CS6"))
+CS1 = io("CS1", Net)
+CS2 = io("CS2", Net)
+CS3 = io("CS3", Net)
+CS4 = io("CS4", Net)
+CS5 = io("CS5", Net)
+CS6 = io("CS6", Net)
 
 # Internal nets
 

--- a/Sensor_Touch/MPR121QR2.zen
+++ b/Sensor_Touch/MPR121QR2.zen
@@ -15,7 +15,6 @@ Datasheet: https://www.nxp.com/docs/en/data-sheet/MPR121.pdf
 """
 
 load("@stdlib/interfaces.zen", "I2c", "Power", "Ground")
-load("@stdlib/checks.zen", "voltage_within")
 
 # Dependencies
 Resistor = Module("@stdlib/generics/Resistor.zen")
@@ -40,7 +39,7 @@ add_electrode_header = config("add_electrode_header", bool, default=True)
 add_test_points = config("add_test_points", bool, default=False)
 
 # External IO
-VDD = io("VDD", Power, checks=voltage_within("1.71V to 3.6V"))
+VDD = io("VDD", Power(voltage="1.71V to 3.6V"))
 VSS = io("VSS", Ground)
 
 # I2C interface


### PR DESCRIPTION
Fixes pcb 0.3.68 deprecation warnings (see `pcb doc --changelog --latest`) across the registry, one commit per file.

**Before:** 902 warnings across 171 files  
**After:** 21 warnings across 21 files (all upstream stdlib issues, see below)

## Fixes applied

- `io() default=` → template-first `io(template)`
- Rebinding in same scope → restructure to bind once per branch
- Power pins on plain `Net` → `Power()` / `Ground()`
- NC pins explicitly wired → omit from `pins`
- Orphan `io()` → wire to chip pins or remove
- `Power(NET=...)` keyword → positional
- Hard-strap address pins via single branch per PCA9548/PCA9685 (no rebinding)
- Fold dead post-rebind aliases (e.g. `_RFOUT_INT = RFOUT`) into initial bindings

## Remaining (upstream, non-actionable here)

- 14 × `generics/Diode.zen` deprecation: the stdlib `generics/Rectifier.zen` and `generics/Zener.zen` are missing `load("../io.zen", "io")` and fail to load, so migration is blocked until the stdlib ships a fix. Only `generics/Tvs.zen` is usable.
- 6 × `generics/Mosfet.zen` deprecation: no replacement in current stdlib.
- 1 × LSM303C datasheet-path resolution warning from `kicad-symbols` cache.

## Verification

`pcb build` passes cleanly (exit 0) after every commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad mechanical refactor across many symbol modules that can subtly change net typing (e.g., `Net`→`Power`/`Ground`), optional pin wiring, and address strapping behavior. While intent is deprecation cleanup, the sheer file count increases the chance of unintended connectivity changes in generated schematics/PCBs.
> 
> **Overview**
> Resolves widespread `pcb` 0.3.68 deprecation warnings by migrating modules away from deprecated `io(..., default=...)` and `checks=voltage_within(...)` usage to template-first `io()` and `Power(voltage=...)` declarations.
> 
> Across many parts, cleans up connectivity by typing supply and switching nets as `Power`/`Ground`, removing explicit `NotConnected()` pins from `Component.pins`, avoiding same-scope rebinding via single-branch bindings (notably for address strapping on PCA95xx/PCA9685), and tightening optional-pin handling (e.g., output filtering nodes, bidirectional SPI DIO, JTAG/antenna nets, and USB/LDO `Power(...)` call sites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccc8dada9baef83a7efa93cb0077cbfd731bdf64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->