### PR TITLE
Add W25Q128JVE part metadata

### DIFF
--- a/Memory_Flash/W25Q128JVE.zen
+++ b/Memory_Flash/W25Q128JVE.zen
@@ -71,6 +71,7 @@ Component(
     name="W25Q128JVE",
     symbol=Symbol(library="@kicad-symbols/Memory_Flash.kicad_sym", name="W25Q128JVE"),
     footprint=File("@kicad-footprints/Package_SON.pretty/WSON-8-1EP_8x6mm_P1.27mm_EP3.4x4.3mm.kicad_mod"),
+    part=Part(mpn="W25Q128JVEIQ", manufacturer="Winbond Electronics"),
     pins={
         "~{CS}": _CS,
         "CLK": _CLK,


### PR DESCRIPTION
Adds explicit Winbond W25Q128JVEIQ part metadata so the component passes strict BOM validation in pcbc 0.3.84+.\n\nPublished package tag: v0.2.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a metadata-only change that affects BOM/validation output but not electrical connectivity or schematic behavior.
> 
> **Overview**
> Adds a `part=Part(mpn="W25Q128JVEIQ", manufacturer="Winbond Electronics")` field to the `W25Q128JVE` component definition so downstream tooling can perform strict BOM validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466a3b72624157596141251f3cb2574f37900ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->